### PR TITLE
make install_requires more flexible on baseapp_core

### DIFF
--- a/baseapp-core/setup.cfg
+++ b/baseapp-core/setup.cfg
@@ -13,20 +13,20 @@ include_package_data = true
 packages = find:
 python_requires = >=3.6
 install_requires =
-    Django == 3.2.19
-    celery == 5.2.7
-    django-pgtrigger == 4.6.0
-    swapper == 1.3.0
-    django-model-utils == 4.3.1
-    djangorestframework == 3.14.0
-    djangorestframework-expander == 0.2.3
-    drf-extra-fields == 3.4.1
-    graphene == 3.2.1
-    graphene-django == 3.0.0
-    psycopg2-binary == 2.9.5
-    django-phonenumber-field == 7.0.2
-    phonenumbers == 8.13.4
-    easy-thumbnails == 2.8.5
+    Django >= 3.2
+    celery >= 5.2
+    django-pgtrigger >= 4.7
+    swapper >= 1.3
+    django-model-utils >= 4.3
+    djangorestframework >= 3.14
+    djangorestframework-expander >= 0.2
+    drf-extra-fields >= 3.5
+    graphene >= 3.2
+    graphene-django >= 3.1
+    psycopg2-binary >= 2.9
+    django-phonenumber-field >= 7.0
+    phonenumbers >= 8.13
+    easy_thumbnails >= 2.8
 
 [options.package_data]
 baseapp_core =

--- a/baseapp-core/testproject/requirements.txt
+++ b/baseapp-core/testproject/requirements.txt
@@ -1,6 +1,8 @@
 # install "install_requires" from setup.cfg
 -e ./baseapp-core
 
+django==3.2
+
 # test
 freezegun==1.2.1
 pytest==6.2.5

--- a/baseapp-reactions/setup.cfg
+++ b/baseapp-reactions/setup.cfg
@@ -13,13 +13,10 @@ include_package_data = true
 packages = find:
 python_requires = >=3.6
 install_requires =
-    swapper == 1.3.0
-    django-model-utils == 4.3.1
-    graphene == 3.2.1
-    graphene-django == 3.0.0
+    baseapp-core
 
 [options.package_data]
-baseapp_core =
+baseapp_reactions =
     *.j2
     *.html
     *.png


### PR DESCRIPTION
mostly because we might want to support both django 3 and 4

but also for security issues, I think its better to leave for the projects to freeze the minor versions, otherwise minor upgrades would need to come from baseapp_core first, the benefit of having baseapp_core freeze the minor versions is that we can deliver updates to projects using baseapp_core, but to achieve this we would need to not freeze the minor version of baseapp_core in the project's requirements

thoughts?