### PR TITLE
HOTFIX: Deployment environments

### DIFF
--- a/.github/workflows/publish-actions.yml
+++ b/.github/workflows/publish-actions.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Publish Actions
 run-name: ${{ github.actor }} is checking ${{ github.ref }} branch 🚀
 on:
   release:

--- a/.github/workflows/publish-actions.yml
+++ b/.github/workflows/publish-actions.yml
@@ -9,31 +9,39 @@ jobs:
     uses: ./.github/workflows/publish-workflow.yml
     with:
       project: baseapp-auth
+    secrets: inherit
   baseapp-cloudflare-stream-field:
     uses: ./.github/workflows/publish-workflow.yml
     with:
       project: baseapp-cloudflare-stream-field
+    secrets: inherit
   baseapp-core:
     uses: ./.github/workflows/publish-workflow.yml
     with:
       project: baseapp-core
+    secrets: inherit
   baseapp-drf-view-action-permissions:
     uses: ./.github/workflows/publish-workflow.yml
     with:
       project: baseapp-baseapp-drf-view-action-permissions
+    secrets: inherit
   baseapp-email-templates:
     uses: ./.github/workflows/publish-workflow.yml
     with:
       project: baseapp-email-templates
+    secrets: inherit
   baseapp-payments:
     uses: ./.github/workflows/publish-workflow.yml
     with:
       project: baseapp-payments
+    secrets: inherit
   baseapp-reactions:
     uses: ./.github/workflows/publish-workflow.yml
     with:
       project: baseapp-reactions
+    secrets: inherit
   baseapp-social-auth:
     uses: ./.github/workflows/publish-workflow.yml
     with:
       project: baseapp-social-auth
+    secrets: inherit

--- a/.github/workflows/publish-workflow-test.yml
+++ b/.github/workflows/publish-workflow-test.yml
@@ -7,7 +7,7 @@
 #     with:
 #       project: baseapp-auth
 
-name: Project Workflow Test
+name: Publish Workflow Test
 
 on:
   workflow_call:

--- a/.github/workflows/publish-workflow-test.yml
+++ b/.github/workflows/publish-workflow-test.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   publish-workflow:
     runs-on: ubuntu-latest
+    environment: testing
     if: contains(github.event.release.tag_name, inputs.project)
     strategy:
       matrix:

--- a/.github/workflows/publish-workflow.yml
+++ b/.github/workflows/publish-workflow.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   publish-workflow:
     runs-on: ubuntu-latest
+    environment: production
     if: contains(github.event.release.tag_name, inputs.project)
     strategy:
       matrix:
@@ -32,5 +33,6 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: ${{ inputs.project }}/dist/

--- a/.github/workflows/publish-workflow.yml
+++ b/.github/workflows/publish-workflow.yml
@@ -1,4 +1,4 @@
-name: Project Workflow
+name: Publish Workflow
 
 on:
   workflow_call:

--- a/.github/workflows/publish-workflow.yml
+++ b/.github/workflows/publish-workflow.yml
@@ -33,6 +33,5 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: ${{ inputs.project }}/dist/

--- a/baseapp-cloudflare-stream-field/setup.cfg
+++ b/baseapp-cloudflare-stream-field/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = baseapp-cloudflare-stream-field
-version = 0.4
+version = 0.5
 description = A CloudFlare Stream Field for Django with admin integration.
 long_description = file: README.md
 url = https://github.com/silverlogic/django-cloudflare-stream

--- a/baseapp-payments/setup.cfg
+++ b/baseapp-payments/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = baseapp_payments
-version = 0.14
+version = 0.15
 description = A BaseApp app to handle payments.
 long_description = file: README.md
 url = https://bitbucket.org/silverlogic/baseapp-payments-django


### PR DESCRIPTION
Deployments through the releases where still not working, turns out that secrets don't get propagated into reusable workflows so you need to specify to inherit them. I thought it was the lack of environments at the beginning but I'm leaving it bec I kinda liked to have secrets per environment instead