### PR TITLE
Fix SynchronousOnlyOperation when using ASGI

### DIFF
--- a/baseapp-auth/baseapp_auth/rest_framework/change_email/views.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/change_email/views.py
@@ -20,8 +20,10 @@ User = get_user_model()
 
 class ChangeEmailViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
     serializer_class = ChangeEmailRequestSerializer
-    queryset = User.objects.all()
     permission_classes = [permissions.IsAuthenticated]
+
+    def get_queryset(self):
+        return User.objects.all()
 
     def create(self, request, *args, **kwargs):
         """step 1"""

--- a/baseapp-auth/baseapp_auth/rest_framework/users/views.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/users/views.py
@@ -41,9 +41,11 @@ class UsersViewSet(
         permissions.IsAuthenticated,
         UpdateSelfPermission,
     ]
-    queryset = User.objects.all().order_by("id")
     filter_backends = (filters.SearchFilter,)
     search_fields = ("first_name", "last_name")
+
+    def get_queryset(self):
+        return User.objects.all().order_by("id")
 
     @action(
         detail=False,

--- a/baseapp-drf-view-action-permissions/README.md
+++ b/baseapp-drf-view-action-permissions/README.md
@@ -38,12 +38,14 @@ from baseapp_drf_view_action_permissions.action import DjangoActionPermissions
 class UserViewSet(viewsets.ModelViewSet):
     permission_classes = [DjangoActionPermissions, ]
     permission_base = "users" # if not defined the app label would be used
-    queryset = User.objects.all()
     model_class = User # Only required if viewset not using queryset
     # optional perms_map_action to override default behaviour
     perms_map_action = {
         'custom_action': ['users.list_users']
     }
+
+    def get_queryset(self):
+        return User.objects.all()
     ...
 ```
 

--- a/baseapp-drf-view-action-permissions/baseapp_drf_view_action_permissions/tests/test_integration.py
+++ b/baseapp-drf-view-action-permissions/baseapp_drf_view_action_permissions/tests/test_integration.py
@@ -50,7 +50,6 @@ class DummyViewSet(viewsets.GenericViewSet):
     permission_classes = [
         DjangoActionPermissions,
     ]
-    queryset = TestModel.objects.all()
     permission_base = "testmodel"
     perms_map_action = {
         "disable": ["testapp.test_disable"],
@@ -62,6 +61,9 @@ class DummyViewSet(viewsets.GenericViewSet):
             "testapp.add_testmodel",
         ],
     }
+
+    def get_queryset(self):
+        return TestModel.objects.all()
 
     def create(self, *args, **kwargs):
         return response.Response({}, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
Basically just by using `queryset =` on viewset the ASGI sometimes complains we are trying to use a sync operation on async context.