### PR TITLE
BA-1173: Fix auth URL paths

### DIFF
--- a/baseapp-auth/baseapp_auth/rest_framework/urls/auth_authtoken.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/urls/auth_authtoken.py
@@ -12,4 +12,4 @@ __all__ = [
     "urlpatterns",
 ]
 
-urlpatterns = [re_path(r"/", include(authtoken_router.urls))]
+urlpatterns = [re_path(r"", include(authtoken_router.urls))]

--- a/baseapp-auth/baseapp_auth/rest_framework/urls/auth_jwt.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/urls/auth_jwt.py
@@ -7,7 +7,7 @@ __all__ = [
 
 urlpatterns = [
     # JWT login
-    re_path(r"/", TokenObtainPairView.as_view(), name="jwt"),
+    re_path(r"$", TokenObtainPairView.as_view(), name="jwt"),
     # JWT token refresh
-    re_path(r"/refresh", TokenRefreshView.as_view(), name="jwt-token-refresh"),
+    re_path(r"refresh", TokenRefreshView.as_view(), name="jwt-token-refresh"),
 ]

--- a/baseapp-auth/baseapp_auth/tests/integration/api_v1/test_login.py
+++ b/baseapp-auth/baseapp_auth/tests/integration/api_v1/test_login.py
@@ -92,7 +92,7 @@ class TestLoginAuthToken(TestLoginBase):
 
 
 class TestLoginJwt(TestLoginBase):
-    login_endpoint_path = "/v1/auth/jwt/login"
+    login_endpoint_path = "/v1/auth/jwt/"
 
     @pytest.fixture
     def data(self):

--- a/baseapp-auth/testproject/urls.py
+++ b/baseapp-auth/testproject/urls.py
@@ -12,8 +12,8 @@ __all__ = [
 
 v1_urlpatterns = [
     re_path(r"", include(account_router.urls)),
-    re_path(r"auth/authtoken", include(auth_authtoken_urls)),
-    re_path(r"auth/jwt", include(auth_jwt_urls)),
+    re_path(r"auth/authtoken/", include(auth_authtoken_urls)),
+    re_path(r"auth/jwt/", include(auth_jwt_urls)),
     re_path(r"auth/mfa", include(auth_mfa_urls)),
     re_path(r"auth/mfa/jwt", include(auth_mfa_jwt_urls)),
 ]


### PR DESCRIPTION
The refresh path was not working for me and we were getting some warnings about a trailing slash. This should fix the paths