### PR TITLE
Skip non-existint models from generate_uml

### DIFF
--- a/baseapp-core/baseapp_core/management/commands/generate_uml.py
+++ b/baseapp-core/baseapp_core/management/commands/generate_uml.py
@@ -82,7 +82,9 @@ class Command(BaseCommand):
             app_label = re.sub(r"^(apps).(.+)$", r"\2", app_config.name)
             self.available_apps.append(app_label)
             for ct in ContentType.objects.filter(app_label=app_label):
-                self.available_models.append(ct.model_class().__name__)
+                Model = ct.model_class()
+                if Model is not None:
+                    self.available_models.append(ct.model_class().__name__)
 
     def add_arguments(self, parser):
         parser.add_argument(


### PR DESCRIPTION
Sometimes we can get a ContentType that doesn't exist anymore as a model