### PR TITLE
Update default email template and sanitize template content

### DIFF
--- a/baseapp-message-templates/README.md
+++ b/baseapp-message-templates/README.md
@@ -45,13 +45,51 @@ TEMPLATES  =  [
 	},
 ]
 ```
-  
-## Set default base template (optional)
 
-If you want to use a default base template that your emails will automatically inherit from, add the path to that template to your settings. Note that this base template won't apply to e-mails that are created on SendGrid.
+## Default Email Template
 
-```py
-DEFAULT_EMAIL_TEMPLATE = [your_path]
+In our Django application, you have the option to use a default email template. This template acts as a wrapper for your other email templates, ensuring a consistent layout and style across all your emails.
+
+
+### Using the Default Template
+
+To effectively utilize the default template:
+
+1. **Create the Default Template**
+
+   Ensure your default template includes a placeholder for the child template content. This is done using the `template_content|safe` variable in your Jinja2 template. 
+
+   Example:
+   ```html
+   <html>
+   <body>
+     <div>
+       <!-- Your default template layout -->
+       <div class="content">
+         {{ template_content|safe }}
+       </div>
+       <!-- More of your default template layout -->
+     </div>
+   </body>
+   </html>
+
+
+2. **Render Child Templates**
+
+	When rendering a child template, pass the content as a string to template_content. `Jinja2` will insert this content into the default template at the location of {{ template_content|safe }}.
+
+3. **Sanitize for Security:**
+	To ensure security, especially since we're using the safe filter, it's important to sanitize `template_content` to prevent XSS (Cross-Site Scripting) attacks. This process removes or neutralizes any potentially harmful scripts that might be part of the content.
+
+
+### Setting Default Base Template (Optional)
+
+If you want to use a default base template that your emails will automatically inherit from, add the path to that template in your Django settings. This configuration allows you to define a consistent layout or design for your emails. Note that this base template won't apply to emails created directly in SendGrid.
+
+In your `settings.py`:
+
+```python
+DEFAULT_EMAIL_TEMPLATE = "path/to/your/default/template" # ex: "emails/base-template"
 ```
 
 ## Setup SendGrid credentials (optional)

--- a/baseapp-message-templates/setup.cfg
+++ b/baseapp-message-templates/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = baseapp_message_templates
-version = 1.5
+version = 1.6
 description = A BaseApp app that allows the use of customizable e-mail and sms templates.
 long_description = file: README.md
 url = https://github.com/silverlogic/baseapp-backend
@@ -37,6 +37,7 @@ install_requires =
     django-nested-admin == 3.3.3
     django-jinja == 2.10.2
     lxml == 4.9.3
+    nh3==0.2.15
 
 
 [tool:pytest]


### PR DESCRIPTION
* remove previous logic that was programmatically replacing the `{% block_content %}` with the child's content and use` render_to_string `'s context instead
*  sanitize the final HTML content
* remove `{% load my_filters %}`  since since wasn't being used and could've be replaced by [jinja2 custom filters](https://jinja.palletsprojects.com/en/3.1.x/api/#writing-filters)
