### PR TITLE
BA-1305: Inject up-to-date claims to access token on refresh

### DIFF
--- a/baseapp-auth/README.md
+++ b/baseapp-auth/README.md
@@ -89,6 +89,16 @@ SIMPLE_JWT = {
 }
 JWT_CLAIM_SERIALIZER_CLASS = "baseapp_auth.rest_framework.users.serializers.UserBaseSerializer"
 ```
+We override some settings from the Simple JWT library by default to make some baseapp features work properly. They look like the following:
+```py
+SIMPLE_JWT = {
+    "TOKEN_OBTAIN_SERIALIZER": "baseapp_auth.rest_framework.jwt.serializers.BaseJwtLoginSerializer",
+    "TOKEN_REFRESH_SERIALIZER": "baseapp_auth.rest_framework.jwt.serializers.BaseJwtRefreshSerializer",
+}
+
+JWT_CLAIM_SERIALIZER_CLASS = "baseapp_auth.rest_framework.users.serializers.UserBaseSerializer"
+```
+However, any setting defined on the project will take precedence over the default ones.
 
 There is a constance config for password expiration interval:
 

--- a/baseapp-auth/baseapp_auth/apps.py
+++ b/baseapp-auth/baseapp_auth/apps.py
@@ -1,5 +1,7 @@
 from django.apps import AppConfig
 
+from .settings import JWT_CLAIM_SERIALIZER_CLASS, SIMPLE_JWT
+
 
 class AuthConfig(AppConfig):
     default = True
@@ -8,4 +10,13 @@ class AuthConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
 
     def ready(self):
-        pass
+        from django.conf import settings  # noqa
+
+        # Set default settings
+        settings.SIMPLE_JWT = {
+            **SIMPLE_JWT,
+            **getattr(settings, "SIMPLE_JWT", {}),
+        }
+        settings.JWT_CLAIM_SERIALIZER_CLASS = getattr(
+            settings, "JWT_CLAIM_SERIALIZER_CLASS", JWT_CLAIM_SERIALIZER_CLASS
+        )

--- a/baseapp-auth/baseapp_auth/rest_framework/jwt/tokens.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/jwt/tokens.py
@@ -1,0 +1,26 @@
+from django.contrib.auth import get_user_model
+from rest_framework_simplejwt.tokens import AccessToken, RefreshToken
+
+User = get_user_model()
+
+
+class CustomClaimRefreshToken(RefreshToken):
+    """
+    Refresh token that always uses the most up-to-date claim data
+    """
+
+    def __init__(self, *args, ClaimSerializerClass=None, **kwargs) -> None:
+        self.claim_serializer_class = ClaimSerializerClass
+        super().__init__(*args, **kwargs)
+
+    @property
+    def access_token(self) -> AccessToken:
+        access = super().access_token
+
+        user = User.objects.get(id=access["user_id"])
+        user_data = self.claim_serializer_class(user).data
+
+        for key, value in user_data.items():
+            access[key] = value
+
+        return access

--- a/baseapp-auth/baseapp_auth/settings.py
+++ b/baseapp-auth/baseapp_auth/settings.py
@@ -1,0 +1,6 @@
+SIMPLE_JWT = {
+    "TOKEN_OBTAIN_SERIALIZER": "baseapp_auth.rest_framework.jwt.serializers.BaseJwtLoginSerializer",
+    "TOKEN_REFRESH_SERIALIZER": "baseapp_auth.rest_framework.jwt.serializers.BaseJwtRefreshSerializer",
+}
+
+JWT_CLAIM_SERIALIZER_CLASS = "baseapp_auth.rest_framework.users.serializers.UserBaseSerializer"

--- a/baseapp-auth/setup.cfg
+++ b/baseapp-auth/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = baseapp_auth
-version = 0.2.5
+version = 0.2.6
 description = BaseApp Auth
 long_description = file: README.md
 url = https://github.com/silverlogic/baseapp-backend


### PR DESCRIPTION
This fixes the issues with the user update flows, where the token has stale data. Whenever we update the user's data, we can just call `refreshAccessToken(ACCESS_COOKIE_NAME, REFRESH_COOKIE_NAME)` on success and that should get a new access token with the fresh user data and save it to the cookie. In my tests I also updated the useUser hook to be like the following:
```
import { useEffect, useState } from 'react'

import { getUser } from '@baseapp-frontend/authentication'

import { IUser } from 'types/user'

export const useUser = () => {
  const [user, setUser] = useState<Partial<IUser> | null>(null)

  useEffect(() => {
    const syncGetUser = async () => {
      setUser(await getUser())
    }

    syncGetUser()
  }, [])

  return user
}
```
because I wasn't sure if the getUser function can be used directly in a react hook, since it's async. Just FYI if that helps someone.