### PR TITLE
ELITE-497: baseapp url shortening pointing to /v1

### DIFF
--- a/baseapp-core/baseapp_core/models.py
+++ b/baseapp-core/baseapp_core/models.py
@@ -6,6 +6,13 @@ from django.utils.deconstruct import deconstructible
 from django.utils.translation import gettext_lazy as _
 
 
+class CaseInsensitiveCharField(models.CharField):
+    description = _("Case insensitive character")
+
+    def db_type(self, connection):
+        return "citext"
+
+
 class CaseInsensitiveTextField(models.TextField):
     description = _("Case insensitive text")
 

--- a/baseapp-core/setup.cfg
+++ b/baseapp-core/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = baseapp-core
-version = 0.2.12
+version = 0.2.13
 description = BaseApp Core
 long_description = file: README.md
 url = https://github.com/silverlogic/baseapp-backend

--- a/baseapp-url-shortening/baseapp_url_shortening/admin.py
+++ b/baseapp-url-shortening/baseapp_url_shortening/admin.py
@@ -12,5 +12,5 @@ class ShortUrlAdmin(admin.ModelAdmin):
 
     def shortened_url(self, instance: ShortUrl) -> str | None:
         if front_url := getattr(settings, "FRONT_URL", None):
-            return urllib.parse.urljoin(front_url, instance.short_url_path)
+            return urllib.parse.urljoin(front_url, instance.short_url_path).replace("/v1/", "/")
         return None

--- a/baseapp-url-shortening/baseapp_url_shortening/models.py
+++ b/baseapp-url-shortening/baseapp_url_shortening/models.py
@@ -10,7 +10,7 @@ class ShortUrl(TimeStampedModel):
 
     @property
     def short_url_path(self) -> str:
-        return reverse("short_url_redirect_full_url", kwargs=dict(short_code=self.short_code))
+        return reverse("v1:short_url_redirect_full_url", kwargs=dict(short_code=self.short_code))
 
     def save(self, *args, **kwargs):
         creating = not self.pk

--- a/baseapp-url-shortening/baseapp_url_shortening/tests/integration/test_url_shortening.py
+++ b/baseapp-url-shortening/baseapp_url_shortening/tests/integration/test_url_shortening.py
@@ -13,5 +13,5 @@ class TestURLShortening:
         assert r.url == instance.full_url
 
     def test_redirect_nonexistent_short_code(self, client):
-        response = client.get("/c/invalid_code")
+        response = client.get("/v1/c/invalid_code")
         assert response.status_code == 404

--- a/baseapp-url-shortening/setup.cfg
+++ b/baseapp-url-shortening/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = baseapp_url_shortening
-version = 0.1.2
+version = 0.1.3
 description = BaseApp URL Shortening
 long_description = file: README.md
 url = https://github.com/silverlogic/baseapp-backend

--- a/baseapp-url-shortening/testproject/urls.py
+++ b/baseapp-url-shortening/testproject/urls.py
@@ -5,7 +5,11 @@ __all__ = [
     "urlpatterns",
 ]
 
+v1_urlpatterns = [
+    re_path(r"", include("baseapp_url_shortening.urls")),
+]
+
 urlpatterns = [
     re_path(r"^admin/", admin.site.urls),
-    re_path(r"", include("baseapp_url_shortening.urls")),
+    re_path(r"v1/", include((v1_urlpatterns, "v1"), namespace="v1")),
 ]


### PR DESCRIPTION
Url shortening view should use /v1 so we can use `NEXT_PUBLIC_API_BASE_URL = app.tsl.io/v1` (front url + /v1)
The redirection order should work like that:
* user access shortened url -> `app.tsl.io/c/123abc`
* user gets redirected to `app.tsl.io/v1/c/123abc`
* the backend returns the full url and user is redirected to `app.tsl.io/some-route`