### PR TITLE
BA-1348 forgot password message

### DIFF
--- a/baseapp-auth/baseapp_auth/rest_framework/forgot_password/serializers.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/forgot_password/serializers.py
@@ -16,10 +16,7 @@ class ForgotPasswordSerializer(serializers.Serializer):
     email = serializers.EmailField()
 
     def validate_email(self, email):
-        try:
-            self.user = User.objects.get(email=email)
-        except User.DoesNotExist:
-            raise serializers.ValidationError(_("Email does not exist."))
+        self.user = User.objects.filter(email=email).first()
         return email
 
 

--- a/baseapp-auth/baseapp_auth/tests/integration/test_forgot_password.py
+++ b/baseapp-auth/baseapp_auth/tests/integration/test_forgot_password.py
@@ -25,21 +25,30 @@ class TestForgotPassword(ApiMixin):
 
     def test_when_email_doesnt_exist(self, data, client):
         r = client.post(self.reverse(), data)
-        h.responseBadRequest(r)
-        assert r.data["email"] == ["Email does not exist."]
+        h.responseOk(r)
+        assert (
+            r.data["message"]
+            == "A reset password link will be sent to you if an account is registered under that email."
+        )
 
     def test_when_email_exist(self, client, data, outbox, deep_link_mock_success):
         UserFactory(email=data["email"])
         r = client.post(self.reverse(), data)
         h.responseOk(r)
-        assert r.data["email"] == "admin@tsl.io"
+        assert (
+            r.data["message"]
+            == "A reset password link will be sent to you if an account is registered under that email."
+        )
         assert len(outbox) == 1
 
     def test_fetch_deep_link_error(self, client, data, outbox, deep_link_mock_error):
         UserFactory(email=data["email"])
         r = client.post(self.reverse(), data)
         h.responseOk(r)
-        assert r.data["email"] == "admin@tsl.io"
+        assert (
+            r.data["message"]
+            == "A reset password link will be sent to you if an account is registered under that email."
+        )
         assert len(outbox) == 1
 
     def test_sends_reset_email(self, client, data, outbox):


### PR DESCRIPTION
**Acceptance Criteria** 
Right now when you ask for a password for an email that doesn't exist we get "Email does not exist."

This is a kind of privacy issue where people can check if you have an issue for that email, ideally both success and error message should look the same, like:

A reset password link will be sent to you if an account is registered under that email. 

**Approvd** 
https://app.approvd.io/projects/BA/stories/30513