### PR TITLE
ELITE-671: implement jwt middleware for ASGI application

### DIFF
--- a/baseapp-core/baseapp_core/channels.py
+++ b/baseapp-core/baseapp_core/channels.py
@@ -1,3 +1,5 @@
+import logging
+
 from channels.db import database_sync_to_async
 from channels.middleware import BaseMiddleware
 
@@ -32,5 +34,74 @@ class TokenAuthMiddleware(BaseMiddleware):
 
         if token and not token.user.is_active:
             raise ValueError("User inactive or deleted")
+
+        return await super().__call__(scope, receive, send)
+
+
+class JWTAuthMiddleware(BaseMiddleware):
+    def __init__(self, inner, *args, **kwargs):
+        from rest_framework_simplejwt.authentication import JWTAuthentication
+
+        super().__init__(inner, *args, **kwargs)
+        self._auth = JWTAuthentication()
+
+    @database_sync_to_async
+    def get_jwt_user_instance(self, token):
+        from rest_framework_simplejwt.exceptions import (
+            AuthenticationFailed,
+            InvalidToken,
+            TokenError,
+        )
+
+        if self._auth is None:
+            raise RuntimeError("JWTAuthMiddleware not initialized")
+
+        try:
+            validated_token = self._auth.get_validated_token(token)
+            return self._auth.get_user(validated_token)
+        except (InvalidToken, AuthenticationFailed, TokenError) as e:
+            logging.error(e)
+            return None
+
+    @database_sync_to_async
+    def refresh_access_token(self, refresh_token):
+        from rest_framework_simplejwt.exceptions import TokenError
+        from rest_framework_simplejwt.tokens import RefreshToken
+
+        try:
+            refresh = RefreshToken(refresh_token)
+            return str(refresh.access_token)
+        except TokenError as e:
+            logging.error(e)
+            return None
+
+    async def __call__(self, scope, receive, send):
+        if "Authorization" not in scope["subprotocols"]:
+            raise ValueError("Missing token")
+
+        # handle token and user retrieval
+        token_index = scope["subprotocols"].index("Authorization")
+        try:
+            token = scope["subprotocols"][token_index + 1]
+        except IndexError:
+            token = ""
+        user = await self.get_jwt_user_instance(token)
+
+        # handle token refresh
+        if not user and "Refresh" in scope["subprotocols"]:
+            refresh_index = scope["subprotocols"].index("Refresh")
+            try:
+                refresh_token = scope["subprotocols"][refresh_index + 1]
+                new_access_token = await self.refresh_access_token(refresh_token)
+                if new_access_token:
+                    user = await self.get_jwt_user_instance(new_access_token)
+                    scope["subprotocols"][token_index + 1] = new_access_token
+            except IndexError:
+                refresh_token = ""
+
+        if user and not user.is_active:
+            raise ValueError("User inactive or deleted")
+        if user:
+            scope["user"] = user
 
         return await super().__call__(scope, receive, send)

--- a/baseapp-core/baseapp_core/tests/test_jwt_auth_middleware.py
+++ b/baseapp-core/baseapp_core/tests/test_jwt_auth_middleware.py
@@ -1,0 +1,176 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from channels.middleware import BaseMiddleware
+from rest_framework_simplejwt.exceptions import InvalidToken
+
+from baseapp_core.channels import JWTAuthMiddleware
+
+pytestmark = pytest.mark.django_db
+
+
+class TestBaseMiddleware(BaseMiddleware):
+    async def __call__(self, scope, receive, send):
+        pass
+
+
+class TestJWTAuthMiddleware:
+    @pytest.fixture
+    def middleware(self):
+        return JWTAuthMiddleware(TestBaseMiddleware(inner=None))
+
+    @pytest.mark.asyncio
+    @patch("rest_framework_simplejwt.authentication.JWTAuthentication.get_validated_token")
+    @patch("rest_framework_simplejwt.authentication.JWTAuthentication.get_user")
+    async def test_jwt_auth_middleware_valid_token(
+        self, mock_get_user, mock_get_validated_token, middleware
+    ):
+        """
+        Scenario:
+            - A valid JWT token is provided in the Authorization header.
+        Expected behavior:
+            - The token is validated, and the corresponding user is set in the scope.
+        """
+
+        mock_user = MagicMock()
+        mock_user.is_active = True
+        mock_get_validated_token.return_value = "valid_token"
+        mock_get_user.return_value = mock_user
+
+        scope = {"subprotocols": ["Authorization", "Bearer valid_jwt_token"]}
+
+        async def mock_receive():
+            return {}
+
+        async def mock_send(message):
+            pass
+
+        # Act
+        await middleware(scope, mock_receive, mock_send)
+
+        # Assert
+        assert scope["user"] == mock_user
+        mock_get_validated_token.assert_called_once_with("Bearer valid_jwt_token")
+        mock_get_user.assert_called_once_with("valid_token")
+
+    @pytest.mark.asyncio
+    @patch("rest_framework_simplejwt.authentication.JWTAuthentication.get_validated_token")
+    @patch("rest_framework_simplejwt.authentication.JWTAuthentication.get_user")
+    async def test_jwt_auth_middleware_invalid_token(
+        self, mock_get_user, mock_get_validated_token, middleware
+    ):
+        """
+        Scenario:
+            - An invalid JWT token is provided in the Authorization header.
+        Expected behavior:
+            - The token validation fails, and no user is set in the scope.
+        """
+
+        mock_get_validated_token.side_effect = InvalidToken("Invalid token")
+
+        scope = {"subprotocols": ["Authorization", "Bearer invalid_jwt_token"]}
+
+        async def mock_receive():
+            return {}
+
+        async def mock_send(message):
+            pass
+
+        await middleware(scope, mock_receive, mock_send)
+
+        assert "user" not in scope
+        mock_get_validated_token.assert_called_once_with("Bearer invalid_jwt_token")
+        mock_get_user.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("rest_framework_simplejwt.authentication.JWTAuthentication.get_validated_token")
+    @patch("rest_framework_simplejwt.authentication.JWTAuthentication.get_user")
+    @patch("baseapp_core.channels.JWTAuthMiddleware.refresh_access_token")
+    async def test_jwt_auth_middleware_refresh_token(
+        self, mock_refresh_access_token, mock_get_user, mock_get_validated_token, middleware
+    ):
+        """
+        Scenario:
+            - An invalid JWT token is provided, but a valid refresh token is available.
+        Expected behavior:
+            - The access token is refreshed, and the corresponding user is set in the scope with the new token.
+        """
+
+        mock_user = MagicMock()
+        mock_user.is_active = True
+        mock_get_validated_token.side_effect = [InvalidToken("Invalid token"), "new_valid_token"]
+        mock_get_user.return_value = mock_user
+        mock_refresh_access_token.return_value = "new_access_token"
+
+        scope = {
+            "subprotocols": [
+                "Authorization",
+                "Bearer invalid_jwt_token",
+                "Refresh",
+                "valid_refresh_token",
+            ]
+        }
+
+        async def mock_receive():
+            return {}
+
+        async def mock_send(message):
+            pass
+
+        await middleware(scope, mock_receive, mock_send)
+
+        assert scope["subprotocols"][1] == "new_access_token"
+        mock_get_validated_token.assert_any_call("Bearer invalid_jwt_token")
+        mock_get_validated_token.assert_any_call("new_access_token")
+        mock_refresh_access_token.assert_called_once_with("valid_refresh_token")
+        assert scope["user"] == mock_user
+        mock_get_user.assert_called_with("new_valid_token")
+
+    @pytest.mark.asyncio
+    async def test_jwt_auth_middleware_missing_token(self, middleware):
+        """
+        Scenario:
+            - No Authorization token is provided in the subprotocols.
+        Expected behavior:
+            - A ValueError is raised indicating the missing token.
+        """
+
+        scope = {"subprotocols": []}
+
+        async def mock_receive():
+            return {}
+
+        async def mock_send(message):
+            pass
+
+        with pytest.raises(ValueError, match="Missing token"):
+            await middleware(scope, mock_receive, mock_send)
+
+    @pytest.mark.asyncio
+    @patch("rest_framework_simplejwt.authentication.JWTAuthentication.get_validated_token")
+    @patch("rest_framework_simplejwt.authentication.JWTAuthentication.get_user")
+    async def test_jwt_auth_middleware_inactive_user(
+        self, mock_get_user, mock_get_validated_token, middleware
+    ):
+        """
+        Scenario:
+            - A valid JWT token is provided, but the corresponding user is inactive.
+        Expected behavior:
+            - A ValueError is raised indicating the user is inactive or deleted.
+        """
+
+        mock_user = MagicMock()
+        mock_user.is_active = False
+        mock_get_validated_token.return_value = "valid_token"
+        mock_get_user.return_value = mock_user
+
+        scope = {"subprotocols": ["Authorization", "Bearer valid_jwt_token"]}
+
+        async def mock_receive():
+            return {}
+
+        async def mock_send(message):
+            pass
+
+        with pytest.raises(ValueError, match="User inactive or deleted"):
+            await middleware(scope, mock_receive, mock_send)

--- a/baseapp-core/setup.cfg
+++ b/baseapp-core/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = baseapp-core
-version = 0.3.1
+version = 0.3.2
 description = BaseApp Core
 long_description = file: README.md
 url = https://github.com/silverlogic/baseapp-backend


### PR DESCRIPTION
* Context:
This PR introduces a new `JWTAuthMiddleware` to handle JWT authentication for WebSocket connections in the ASGI application

* What was done:
  * validates and/or refreshes JWT tokens provided in the scope subprotocol
  * sets the authenticated user in the connection scope
  * handles cases for invalid tokens, missing tokens, and inactive users

Note:
* I added the new `JWTAuthMiddleware` into `baseapp-core` package because the `TokenAuthMiddleware` was already there. but I don't know if that's the best place to add it. Maybe `baseapp-auth`?