### PR TITLE
fix tests for django 5.0

### DIFF
--- a/.github/workflows/project-workflow.yml
+++ b/.github/workflows/project-workflow.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.12"]
-        django-version: ["4.2", "5.0"]
+        django-version: ["4.2.15", "5.0.8"]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Version 5.1 got released a few days ago and is breaking tests, this freezes django version to 5.0.x for the time being