### PR TITLE
baseapp-core:  BA-1627 increase tests coverage

### DIFF
--- a/baseapp-core/baseapp_core/tests/test_case_insensitive_fields.py
+++ b/baseapp-core/baseapp_core/tests/test_case_insensitive_fields.py
@@ -1,9 +1,10 @@
 from django.db import connection
 from django.test import TestCase
+
 from baseapp_core.models import (
     CaseInsensitiveCharField,
-    CaseInsensitiveTextField,
     CaseInsensitiveEmailField,
+    CaseInsensitiveTextField,
 )
 
 

--- a/baseapp-core/baseapp_core/tests/test_case_insensitive_fields.py
+++ b/baseapp-core/baseapp_core/tests/test_case_insensitive_fields.py
@@ -1,5 +1,4 @@
 from django.db import connection
-from django.test import TestCase
 
 from baseapp_core.models import (
     CaseInsensitiveCharField,
@@ -8,7 +7,7 @@ from baseapp_core.models import (
 )
 
 
-class TestCaseInsensitiveFields(TestCase):
+class TestCaseInsensitiveFields:
 
     def test_case_insensitive_char_field_db_type(self):
         field = CaseInsensitiveCharField()

--- a/baseapp-core/baseapp_core/tests/test_case_insensitive_fields.py
+++ b/baseapp-core/baseapp_core/tests/test_case_insensitive_fields.py
@@ -1,0 +1,25 @@
+from django.db import connection
+from django.test import TestCase
+from baseapp_core.models import (
+    CaseInsensitiveCharField,
+    CaseInsensitiveTextField,
+    CaseInsensitiveEmailField,
+)
+
+
+class TestCaseInsensitiveFields(TestCase):
+
+    def test_case_insensitive_char_field_db_type(self):
+        field = CaseInsensitiveCharField()
+        db_type = field.db_type(connection)
+        assert db_type == "citext", f"Expected 'citext', but got {db_type}"
+
+    def test_case_insensitive_text_field_db_type(self):
+        field = CaseInsensitiveTextField()
+        db_type = field.db_type(connection)
+        assert db_type == "citext", f"Expected 'citext', but got {db_type}"
+
+    def test_case_insensitive_email_field_db_type(self):
+        field = CaseInsensitiveEmailField()
+        db_type = field.db_type(connection)
+        assert db_type == "citext", f"Expected 'citext', but got {db_type}"

--- a/baseapp-core/baseapp_core/tests/test_middleware.py
+++ b/baseapp-core/baseapp_core/tests/test_middleware.py
@@ -1,0 +1,80 @@
+from baseapp_core.tests.factories import UserFactory
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
+from unittest.mock import patch
+from baseapp_core.middleware import HistoryMiddleware
+
+
+class HistoryMiddlewareTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.get_response = lambda request: HttpResponse("OK")
+        self.middleware = HistoryMiddleware(self.get_response)
+
+    @patch("baseapp_core.middleware.get_client_ip")
+    @patch("baseapp_core.middleware.pghistory.context")
+    def test_history_middleware_with_authenticated_user(self, mock_context, mock_get_client_ip):
+        request = self.factory.get("/some-path/")
+        request.user = UserFactory()
+        mock_get_client_ip.return_value = ("127.0.0.1", True)
+
+        response = self.middleware(request)
+
+        self.assertEqual(response.status_code, 200)
+        mock_context.assert_called_once_with(
+            user=request.user.pk, url=request.path, clinet_ip="127.0.0.1", is_ip_routable=True
+        )
+
+    @patch("baseapp_core.middleware.get_client_ip")
+    @patch("baseapp_core.middleware.pghistory.context")
+    def test_history_middleware_with_anonymous_user(self, mock_context, mock_get_client_ip):
+        request = self.factory.get("/some-path/")
+        request.user = None
+        mock_get_client_ip.return_value = ("127.0.0.1", True)
+
+        response = self.middleware(request)
+
+        self.assertEqual(response.status_code, 200)
+        mock_context.assert_called_once_with(
+            user=None, url=request.path, clinet_ip="127.0.0.1", is_ip_routable=True
+        )
+
+    @patch("baseapp_core.middleware.get_client_ip")
+    @patch("baseapp_core.middleware.pghistory.context")
+    def test_history_middleware_with_non_routable_ip(self, mock_context, mock_get_client_ip):
+        request = self.factory.get("/some-path/")
+        request.user = UserFactory()
+        mock_get_client_ip.return_value = ("127.0.0.1", False)
+
+        response = self.middleware(request)
+
+        self.assertEqual(response.status_code, 200)
+        mock_context.assert_called_once_with(
+            user=request.user.pk, url=request.path, clinet_ip="127.0.0.1", is_ip_routable=False
+        )
+
+    @patch("baseapp_core.middleware.get_client_ip")
+    @patch("baseapp_core.middleware.pghistory.context")
+    def test_history_middleware_with_post_method(self, mock_context, mock_get_client_ip):
+        request = self.factory.post("/some-path/")
+        request.user = UserFactory()
+        mock_get_client_ip.return_value = ("127.0.0.1", True)
+
+        response = self.middleware(request)
+
+        self.assertEqual(response.status_code, 200)
+        mock_context.assert_called_once_with(
+            user=request.user.pk, url=request.path, clinet_ip="127.0.0.1", is_ip_routable=True
+        )
+
+    @patch("baseapp_core.middleware.get_client_ip")
+    @patch("baseapp_core.middleware.pghistory.context")
+    def test_history_middleware_with_unsupported_method(self, mock_context, mock_get_client_ip):
+        request = self.factory.put("/some-path/")
+        request.user = UserFactory()
+        mock_get_client_ip.return_value = ("127.0.0.1", True)
+
+        response = self.middleware(request)
+
+        self.assertEqual(response.status_code, 200)
+        mock_context.assert_not_called()

--- a/baseapp-core/baseapp_core/tests/test_middleware.py
+++ b/baseapp-core/baseapp_core/tests/test_middleware.py
@@ -1,8 +1,10 @@
-from baseapp_core.tests.factories import UserFactory
+from unittest.mock import patch
+
 from django.http import HttpResponse
 from django.test import RequestFactory, TestCase
-from unittest.mock import patch
+
 from baseapp_core.middleware import HistoryMiddleware
+from baseapp_core.tests.factories import UserFactory
 
 
 class HistoryMiddlewareTest(TestCase):

--- a/baseapp-core/baseapp_core/tests/test_middleware.py
+++ b/baseapp-core/baseapp_core/tests/test_middleware.py
@@ -1,13 +1,13 @@
 from unittest.mock import patch
 
 from django.http import HttpResponse
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, override_settings
 
 from baseapp_core.middleware import HistoryMiddleware
 from baseapp_core.tests.factories import UserFactory
 
 
-class HistoryMiddlewareTest(TestCase):
+class HistoryMiddlewareTest:
     def setUp(self):
         self.factory = RequestFactory()
         self.get_response = lambda request: HttpResponse("OK")
@@ -71,6 +71,7 @@ class HistoryMiddlewareTest(TestCase):
 
     @patch("baseapp_core.middleware.get_client_ip")
     @patch("baseapp_core.middleware.pghistory.context")
+    @override_settings(PGHISTORY_MIDDLEWARE_METHODS=("GET", "POST", "PATCH", "DELETE"))
     def test_history_middleware_with_unsupported_method(self, mock_context, mock_get_client_ip):
         request = self.factory.put("/some-path/")
         request.user = UserFactory()

--- a/baseapp-core/baseapp_core/tests/test_random_name_generators.py
+++ b/baseapp-core/baseapp_core/tests/test_random_name_generators.py
@@ -1,0 +1,52 @@
+import os
+import uuid
+from unittest import mock
+import pytest
+from baseapp_core.models import random_dir_in, random_name_in
+
+
+@pytest.fixture
+def base_dir():
+    return "/test/base/dir"
+
+
+@pytest.fixture
+def filename():
+    return "testfile.txt"
+
+
+def test_random_name_in():
+    directory = "test_dir"
+    filename = "example.txt"
+    random_name = random_name_in(directory)
+
+    result = random_name(mock.Mock(), filename)
+
+    # Check if the result is in the correct directory
+    assert result.startswith(directory)
+
+    # Check if the result has the correct file extension
+    assert result.endswith(".txt")
+
+    # Check if the filename is a valid UUID
+    generated_filename = os.path.basename(result)
+    generated_uuid = generated_filename.split(".")[0]
+    try:
+        uuid.UUID(generated_uuid, version=4)
+    except ValueError:
+        pytest.fail(f"Generated filename '{generated_filename}' is not a valid UUID")
+
+
+def test_random_dir_in_initialization(base_dir):
+    random_dir = random_dir_in(base_dir)
+    assert random_dir.base_dir == base_dir
+
+
+def test_random_dir_in_call(base_dir, filename):
+    random_dir = random_dir_in(base_dir)
+    instance = mock.Mock()
+
+    with mock.patch("uuid.uuid4", return_value=uuid.UUID("12345678123456781234567812345678")):
+        result = random_dir(instance, filename)
+        expected_path = os.path.join(base_dir, "12345678-1234-5678-1234-567812345678", filename)
+        assert result == expected_path

--- a/baseapp-core/baseapp_core/tests/test_random_name_generators.py
+++ b/baseapp-core/baseapp_core/tests/test_random_name_generators.py
@@ -6,6 +6,8 @@ import pytest
 
 from baseapp_core.models import random_dir_in, random_name_in
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.fixture
 def base_dir():

--- a/baseapp-core/baseapp_core/tests/test_random_name_generators.py
+++ b/baseapp-core/baseapp_core/tests/test_random_name_generators.py
@@ -1,7 +1,9 @@
 import os
 import uuid
 from unittest import mock
+
 import pytest
+
 from baseapp_core.models import random_dir_in, random_name_in
 
 

--- a/baseapp-core/baseapp_core/tests/test_token_generator.py
+++ b/baseapp-core/baseapp_core/tests/test_token_generator.py
@@ -1,0 +1,71 @@
+import pytest
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+from baseapp_core.tokens import TokenGenerator
+
+
+class TestTokenGenerator(TokenGenerator):
+    @property
+    def key_salt(self):
+        return "test_salt"
+
+    @property
+    def max_age(self):
+        return 3600
+
+
+class MockObject:
+    def __init__(self, id):
+        self.id = id
+
+
+@pytest.fixture
+def token_generator():
+    return TestTokenGenerator()
+
+
+@pytest.fixture
+def mock_object():
+    return MockObject(id=123)
+
+
+def test_make_token(token_generator, mock_object):
+    token = token_generator.make_token(mock_object)
+    assert token is not None
+    assert isinstance(token, str)
+
+
+def test_get_signing_value(token_generator, mock_object):
+    value = token_generator.get_signing_value(mock_object)
+    assert value == mock_object.id
+
+
+def test_check_token_valid(token_generator, mock_object):
+    token = token_generator.make_token(mock_object)
+    assert token_generator.check_token(mock_object, token) is True
+
+
+def test_check_token_invalid(token_generator, mock_object):
+    invalid_token = urlsafe_base64_encode(force_bytes("invalid_token"))
+    assert token_generator.check_token(mock_object, invalid_token) is False
+
+
+def test_is_value_valid(token_generator, mock_object):
+    value = token_generator.get_signing_value(mock_object)
+    assert token_generator.is_value_valid(mock_object, value) is True
+
+
+def test_decode_token_valid(token_generator, mock_object):
+    token = token_generator.make_token(mock_object)
+    decoded_value = token_generator.decode_token(token)
+    assert decoded_value == mock_object.id
+
+
+def test_decode_token_invalid(token_generator):
+    invalid_token = urlsafe_base64_encode(force_bytes("invalid_token"))
+    assert token_generator.decode_token(invalid_token) is None
+
+
+def test_key_salt_not_implemented():
+    with pytest.raises(NotImplementedError):
+        TokenGenerator().key_salt

--- a/baseapp-core/baseapp_core/tests/test_token_generator.py
+++ b/baseapp-core/baseapp_core/tests/test_token_generator.py
@@ -1,6 +1,7 @@
 import pytest
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
+
 from baseapp_core.tokens import TokenGenerator
 
 


### PR DESCRIPTION
**Acceptance Criteria**
baseapp-core is missing proper tests for a bunch of utils
https://github.com/silverlogic/baseapp-backend/tree/master/baseapp-core

Although there is a test there for baseapp_core.channels.JWTAuthMiddleware, it is not currently running on the CI/CD flow because the testproject is incomplete. So for this story tests should run on CI/CD flow. Follow this PR as an example on how to get this done https://github.com/silverlogic/baseapp-backend/pull/130

Not looking to get 100% test coverage under this story, we can start with very simple stuff like:

**random_name_in
random_dir_in
TokenGenerator
CaseInsensitiveEmailField
CaseInsensitiveTextField
CaseInsensitiveCharField
HistoryMiddleware**

Would be perfect if we can cover some of the rest framework and graphql helpers as well.

Any questions about this reach out to either AP, VG or NP 

**Approvd**
https://app.approvd.io/projects/BA/stories/30500 