### PR TITLE
baseapp-payments: customer subscribe items fix

### DIFF
--- a/baseapp-payments/baseapp_payments/serializers.py
+++ b/baseapp-payments/baseapp_payments/serializers.py
@@ -74,15 +74,15 @@ class SubscribeCustomerSerializer(serializers.Serializer):
             and "premium" in self.plan.slug
         ):
             subscription = self.customer.subscribe(
-                plan=self.plan.price,
                 trial_period_days=config.BASEAPP_PAYMENTS_TRIAL_DAYS,
                 default_payment_method=self.validated_data.get("payment_method_id"),
+                items=[{"plan": self.plan.price}],
             )
             send_subscription_trial_start_email(self.customer.email)
         else:
             subscription = self.customer.subscribe(
-                plan=self.plan.price,
                 default_payment_method=self.validated_data.get("payment_method_id"),
+                items=[{"plan": self.plan.price}],
             )
 
         self.subscriber.subscription_start_request(

--- a/baseapp-payments/setup.cfg
+++ b/baseapp-payments/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = baseapp_payments
-version = 0.16.2
+version = 0.16.3
 description = A BaseApp app to handle payments.
 long_description = file: README.md
 url = https://bitbucket.org/silverlogic/baseapp-payments-django


### PR DESCRIPTION
Fix for the error:
TypeError: subscription_start_request() got an unexpected keyword argument 'price'

It happens when trying to call the function subscribe from a customer instance.
https://www.loom.com/share/1a7752c982054b00828ee3f5bac496b9