### PR TITLE
baseapp-profiles: change profile filter to add name and urlpath query - BA-1737

### DIFF
--- a/baseapp-profiles/baseapp_profiles/graphql/filters.py
+++ b/baseapp-profiles/baseapp_profiles/graphql/filters.py
@@ -1,0 +1,24 @@
+import django_filters
+import swapper
+from django.db.models import Q
+
+Profile = swapper.load_model("baseapp_profiles", "Profile")
+
+
+class ProfileFilter(django_filters.FilterSet):
+    q = django_filters.CharFilter(method="filter_q")
+
+    order_by = django_filters.OrderingFilter(
+        fields=(
+            ("created", "created"),
+            ("followers_count__total", "followers_count_total"),
+            ("following_count__total", "following_count_total"),
+        )
+    )
+
+    class Meta:
+        model = Profile
+        fields = ["q", "order_by"]
+
+    def filter_q(self, queryset, name, value):
+        return queryset.filter(Q(name__icontains=value) | Q(url_paths__path__icontains=value))

--- a/baseapp-profiles/baseapp_profiles/graphql/object_types.py
+++ b/baseapp-profiles/baseapp_profiles/graphql/object_types.py
@@ -1,4 +1,3 @@
-import django_filters
 import graphene
 import swapper
 from baseapp_auth.graphql import PermissionsInterface
@@ -12,6 +11,8 @@ from django.apps import apps
 from django.db.models import Q
 from graphene import relay
 from graphene_django.filter import DjangoFilterConnectionField
+
+from .filters import ProfileFilter
 
 Profile = swapper.load_model("baseapp_profiles", "Profile")
 ProfileUserRole = swapper.load_model("baseapp_profiles", "ProfileUserRole")
@@ -39,12 +40,6 @@ class ProfileUserRoleObjectType(DjangoObjectType, BaseProfileUserRoleObjectType)
 
 class ProfileInterface(relay.Node):
     profile = graphene.Field(get_object_type_for_model(Profile))
-
-
-class ProfileFilter(django_filters.FilterSet):
-    class Meta:
-        model = Profile
-        fields = ["name"]
 
 
 class ProfileMetadata(AbstractMetadataObjectType):

--- a/baseapp-profiles/setup.cfg
+++ b/baseapp-profiles/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = baseapp_profiles
-version = 0.3.0
+version = 0.3.1
 description = BaseApp Profiles
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Modify `ProfileFilter` to allow querying `name` and `urlPath` at the same time

https://silverlogic.atlassian.net/browse/BA-1572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new filtering mechanism for profiles, allowing users to search profiles by name or URL paths.
	- Added a GraphQL query for searching profiles based on a query parameter.

- **Bug Fixes**
	- Improved validation for the search functionality through enhanced testing.

- **Chores**
	- Updated package version from 0.3.0 to 0.3.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->