### PR TITLE
BA-1808 Add basic profile information to JWT claims

### DIFF
--- a/baseapp-auth/baseapp_auth/graphql/object_types.py
+++ b/baseapp-auth/baseapp_auth/graphql/object_types.py
@@ -48,7 +48,7 @@ if apps.is_installed("baseapp_profiles"):
                 return Profile.objects.none()
             return Profile.objects.filter(
                 Q(owner_id=info.context.user.id) | Q(members__user_id=info.context.user.id)
-            )
+            ).distinct()
 
     interfaces += (UserProfiles, ProfileInterface)
 

--- a/baseapp-auth/baseapp_auth/rest_framework/jwt/serializers.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/jwt/serializers.py
@@ -26,13 +26,12 @@ class CustomClaimSerializerMixin:
 class BaseJwtLoginSerializer(
     CustomClaimSerializerMixin, LoginPasswordExpirationMixin, TokenObtainPairSerializer
 ):
-    @classmethod
-    def get_token(cls, user):
+    def get_token(self, user):
         token = super().get_token(user)
 
         # Add custom claims
-        if cls._claim_serializer_class:
-            data = cls.get_claim_serializer_class()(user).data
+        if self._claim_serializer_class:
+            data = self.get_claim_serializer_class()(user, context=self.context).data
             for key, value in data.items():
                 token[key] = value
 

--- a/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 from baseapp_auth.utils.referral_utils import get_user_referral_model, use_referrals
 from baseapp_core.rest_framework.serializers import ModelSerializer
+from baseapp_core.rest_framework.fields import ThumbnailImageField
 from baseapp_referrals.utils import get_referral_code, get_user_from_referral_code
 from constance import config
 from django.contrib.auth import get_user_model
@@ -22,6 +23,7 @@ from baseapp_auth.password_validators import apply_password_validators
 
 class ProfileSerializer(ModelSerializer):
     url_path = serializers.SlugField(required=False)
+    image = ThumbnailImageField(required=False, sizes={"small": (100,100)})
 
     class Meta:
         model = Profile

--- a/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
@@ -1,3 +1,5 @@
+import swapper
+
 from datetime import timedelta
 
 from baseapp_auth.utils.referral_utils import get_user_referral_model, use_referrals
@@ -14,21 +16,29 @@ from rest_framework import serializers
 from .fields import AvatarField
 
 User = get_user_model()
+Profile = swapper.load_model("baseapp_profiles", "Profile")
 
 from baseapp_auth.password_validators import apply_password_validators
 
+class ProfileSerializer(ModelSerializer):
+    url_path = serializers.SlugField(required=False)
+
+    class Meta:
+        model = Profile
+        fields = ("id", "name", "image", "url_path")
+
 
 class UserBaseSerializer(ModelSerializer):
-    name = serializers.CharField(required=False, allow_blank=True, source="first_name")
-    avatar = AvatarField(required=False, allow_null=True)
+    profile = ProfileSerializer(read_only=True)
     email_verification_required = serializers.SerializerMethodField()
     referral_code = serializers.SerializerMethodField()
     referred_by_code = serializers.CharField(required=False, allow_blank=True, write_only=True)
-
+    
     class Meta:
         model = User
         fields = (
             "id",
+            "profile",
             "email",
             "is_email_verified",
             "email_verification_required",
@@ -36,8 +46,6 @@ class UserBaseSerializer(ModelSerializer):
             "is_new_email_confirmed",
             "referral_code",
             "referred_by_code",
-            "avatar",
-            "name",
             "phone_number",
             "preferred_language",
         )

--- a/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
@@ -22,27 +22,26 @@ Profile = swapper.load_model("baseapp_profiles", "Profile")
 
 from baseapp_auth.password_validators import apply_password_validators
 
+
 class JWTProfileSerializer(serializers.ModelSerializer):
     """
     Serializes minimal profile data that will be attached to the JWT token as claim
     """
-    url_path = serializers.SerializerMethodField() # serializers.SlugField(required=False)
+    url_path = serializers.SlugField(required=False)
     id = serializers.SerializerMethodField() 
-    image = ThumbnailImageField(required=False, sizes={"url": (100,100)})
+    image = ThumbnailImageField(required=False, sizes={"small": (100,100)})
 
     class Meta:
         model = Profile
         fields = ("id", "name", "image", "url_path")
 
-    def get_url_path(self, profile):
-        return { 'path': profile.url_path.path}
-
     def get_id(self, profile):
         return get_obj_relay_id(profile)
 
-    def to_representation(self, instance):
-        data = super().to_representation(instance)
-        data['image'].pop('full_size')
+    def to_representation(self, profile):
+        data = super().to_representation(profile)
+        if (data['image'] != None):
+            data['image'] = data['image']['small']
         return data
 
 

--- a/baseapp-profiles/baseapp_profiles/managers.py
+++ b/baseapp-profiles/baseapp_profiles/managers.py
@@ -3,7 +3,7 @@ from django.db import models
 
 class ProfileManager(models.Manager):
     def filter_user_profiles(self, user):
-        return self.filter(models.Q(members__user=user) | models.Q(owner=user))
+        return self.filter(models.Q(members__user=user) | models.Q(owner=user)).distinct()
 
     def get_if_member(self, user, **kwargs):
         if user.is_superuser:


### PR DESCRIPTION
This adds basic profile information (id, name, image, urlPath) to the JWT claims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new `UserProfiles` class for enhanced user profile management in the GraphQL API.
  - Added `JWTProfileSerializer` to streamline profile data serialization in JWT tokens.

- **Improvements**
  - Ensured unique user profiles are returned in the GraphQL API.
  - Updated token generation logic to improve handling of custom claims.
  - Enhanced user serialization process by integrating profile data into JWT tokens.

- **Bug Fixes**
  - Resolved issues with duplicate entries in user profile queries.

These changes enhance user experience by providing distinct profiles and improving the security of token-based authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->