### PR TITLE
Hotfix: Adding custom_tests_path to baseapp-wagtail

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -88,3 +88,4 @@ jobs:
     uses: ./.github/workflows/project-workflow.yml
     with:
       project: baseapp-wagtail
+      custom_tests_path: "baseapp-wagtail"


### PR DESCRIPTION
Fix needed to correct this action error: https://github.com/silverlogic/baseapp-backend/actions/runs/12018249526/job/33502338555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to include a new parameter for custom test paths related to the `baseapp-wagtail` project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->