### PR TITLE
BA-1808 [BE] Add basic profile information to JWT claims

### DIFF
--- a/baseapp-auth/baseapp_auth/graphql/object_types.py
+++ b/baseapp-auth/baseapp_auth/graphql/object_types.py
@@ -49,7 +49,7 @@ if apps.is_installed("baseapp_profiles"):
                 return Profile.objects.none()
             return Profile.objects.filter(
                 Q(owner_id=info.context.user.id) | Q(members__user_id=info.context.user.id)
-            )
+            ).distinct()
 
     interfaces += (UserProfiles, ProfileInterface)
 

--- a/baseapp-auth/baseapp_auth/rest_framework/jwt/serializers.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/jwt/serializers.py
@@ -26,12 +26,13 @@ class CustomClaimSerializerMixin:
 class BaseJwtLoginSerializer(
     CustomClaimSerializerMixin, LoginPasswordExpirationMixin, TokenObtainPairSerializer
 ):
-    def get_token(self, user):
+    @classmethod
+    def get_token(cls, user):
         token = super().get_token(user)
 
         # Add custom claims
-        if self._claim_serializer_class:
-            data = self.get_claim_serializer_class()(user, context=self.context).data
+        if cls._claim_serializer_class:
+            data = cls.get_claim_serializer_class()(user).data
             for key, value in data.items():
                 token[key] = value
 

--- a/baseapp-auth/baseapp_auth/rest_framework/jwt/serializers.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/jwt/serializers.py
@@ -26,13 +26,12 @@ class CustomClaimSerializerMixin:
 class BaseJwtLoginSerializer(
     CustomClaimSerializerMixin, LoginPasswordExpirationMixin, TokenObtainPairSerializer
 ):
-    @classmethod
-    def get_token(cls, user):
+    def get_token(self, user):
         token = super().get_token(user)
 
         # Add custom claims
-        if cls._claim_serializer_class:
-            data = cls.get_claim_serializer_class()(user).data
+        if self._claim_serializer_class:
+            data = self.get_claim_serializer_class()(user, context=self.context).data
             for key, value in data.items():
                 token[key] = value
 

--- a/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
@@ -27,7 +27,7 @@ class JWTProfileSerializer(serializers.ModelSerializer):
     """
     Serializes minimal profile data that will be attached to the JWT token as claim
     """
-    url_path = serializers.SlugField(required=False)
+    url_path = serializers.SlugField(required=False, allow_null=True)
     id = serializers.SerializerMethodField() 
     image = ThumbnailImageField(required=False, sizes={"small": (100,100)})
 
@@ -47,6 +47,7 @@ class JWTProfileSerializer(serializers.ModelSerializer):
 
 class UserBaseSerializer(ModelSerializer):
     profile = JWTProfileSerializer(read_only=True)
+    avatar = AvatarField(required=False, allow_null=True, write_only=True)
     email_verification_required = serializers.SerializerMethodField()
     referral_code = serializers.SerializerMethodField()
     referred_by_code = serializers.CharField(required=False, allow_blank=True, write_only=True)
@@ -55,6 +56,7 @@ class UserBaseSerializer(ModelSerializer):
         model = User
         fields = (
             "id",
+            "avatar",
             "profile",
             "email",
             "is_email_verified",

--- a/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
@@ -28,7 +28,7 @@ class JWTProfileSerializer(serializers.ModelSerializer):
     Serializes minimal profile data that will be attached to the JWT token as claim
     """
     url_path = serializers.SlugField(required=False, allow_null=True)
-    id = serializers.SerializerMethodField() 
+    id = serializers.SerializerMethodField()
     image = ThumbnailImageField(required=False, sizes={"small": (100,100)})
 
     class Meta:
@@ -51,7 +51,7 @@ class UserBaseSerializer(ModelSerializer):
     email_verification_required = serializers.SerializerMethodField()
     referral_code = serializers.SerializerMethodField()
     referred_by_code = serializers.CharField(required=False, allow_blank=True, write_only=True)
-    
+
     class Meta:
         model = User
         fields = (

--- a/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
@@ -39,8 +39,8 @@ class JWTProfileSerializer(serializers.ModelSerializer):
         return get_obj_relay_id(profile)
 
     def get_url_path(self, profile):
-        path_obj = getattr(profile, 'url_path', None)
-        return getattr(path_obj, 'path', None)
+        path_obj = getattr(profile, "url_path", None)
+        return getattr(path_obj, "path", None)
 
     def to_representation(self, profile):
         data = super().to_representation(profile)

--- a/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
@@ -27,8 +27,8 @@ class JWTProfileSerializer(serializers.ModelSerializer):
     Serializes minimal profile data that will be attached to the JWT token as claim
     """
 
-    url_path = serializers.SlugField(required=False, allow_null=True)
     id = serializers.SerializerMethodField()
+    url_path = serializers.SerializerMethodField()
     image = ThumbnailImageField(required=False, sizes={"small": (100, 100)})
 
     class Meta:
@@ -37,6 +37,12 @@ class JWTProfileSerializer(serializers.ModelSerializer):
 
     def get_id(self, profile):
         return get_obj_relay_id(profile)
+
+    def get_url_path(self, profile):
+        if hasattr(profile, 'url_path'):
+            return profile.url_path.path
+        else:
+            return None
 
     def to_representation(self, profile):
         data = super().to_representation(profile)

--- a/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
@@ -39,10 +39,8 @@ class JWTProfileSerializer(serializers.ModelSerializer):
         return get_obj_relay_id(profile)
 
     def get_url_path(self, profile):
-        if hasattr(profile, 'url_path'):
-            return profile.url_path.path
-        else:
-            return None
+        path_obj = getattr(profile, 'url_path', None)
+        return getattr(path_obj, 'path', None)
 
     def to_representation(self, profile):
         data = super().to_representation(profile)

--- a/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 from baseapp_auth.utils.referral_utils import get_user_referral_model, use_referrals
 from baseapp_core.rest_framework.serializers import ModelSerializer
+from baseapp_core.rest_framework.fields import ThumbnailImageField
 from baseapp_referrals.utils import get_referral_code, get_user_from_referral_code
 from constance import config
 from django.contrib.auth import get_user_model
@@ -22,6 +23,7 @@ from baseapp_auth.password_validators import apply_password_validators
 
 class ProfileSerializer(ModelSerializer):
     url_path = serializers.SlugField(required=False)
+    image = ThumbnailImageField(required=False, sizes={"small": (100,100)})
 
     class Meta:
         model = Profile

--- a/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
@@ -1,11 +1,10 @@
-import swapper
-
 from datetime import timedelta
 
+import swapper
 from baseapp_auth.utils.referral_utils import get_user_referral_model, use_referrals
 from baseapp_core.graphql import get_obj_relay_id
-from baseapp_core.rest_framework.serializers import ModelSerializer
 from baseapp_core.rest_framework.fields import ThumbnailImageField
+from baseapp_core.rest_framework.serializers import ModelSerializer
 from baseapp_referrals.utils import get_referral_code, get_user_from_referral_code
 from constance import config
 from django.contrib.auth import get_user_model
@@ -27,9 +26,10 @@ class JWTProfileSerializer(serializers.ModelSerializer):
     """
     Serializes minimal profile data that will be attached to the JWT token as claim
     """
+
     url_path = serializers.SlugField(required=False, allow_null=True)
     id = serializers.SerializerMethodField()
-    image = ThumbnailImageField(required=False, sizes={"small": (100,100)})
+    image = ThumbnailImageField(required=False, sizes={"small": (100, 100)})
 
     class Meta:
         model = Profile
@@ -40,8 +40,8 @@ class JWTProfileSerializer(serializers.ModelSerializer):
 
     def to_representation(self, profile):
         data = super().to_representation(profile)
-        if data['image'] is not None:
-            data['image'] = data['image']['small']
+        if data["image"] is not None:
+            data["image"] = data["image"]["small"]
         return data
 
 

--- a/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
@@ -1,3 +1,5 @@
+import swapper
+
 from datetime import timedelta
 
 from baseapp_auth.utils.referral_utils import get_user_referral_model, use_referrals
@@ -14,21 +16,29 @@ from rest_framework import serializers
 from .fields import AvatarField
 
 User = get_user_model()
+Profile = swapper.load_model("baseapp_profiles", "Profile")
 
 from baseapp_auth.password_validators import apply_password_validators
 
+class ProfileSerializer(ModelSerializer):
+    url_path = serializers.SlugField(required=False)
+
+    class Meta:
+        model = Profile
+        fields = ("id", "name", "image", "url_path")
+
 
 class UserBaseSerializer(ModelSerializer):
-    name = serializers.CharField(required=False, allow_blank=True, source="first_name")
-    avatar = AvatarField(required=False, allow_null=True)
+    profile = ProfileSerializer(read_only=True)
     email_verification_required = serializers.SerializerMethodField()
     referral_code = serializers.SerializerMethodField()
     referred_by_code = serializers.CharField(required=False, allow_blank=True, write_only=True)
-
+    
     class Meta:
         model = User
         fields = (
             "id",
+            "profile",
             "email",
             "is_email_verified",
             "email_verification_required",
@@ -36,8 +46,6 @@ class UserBaseSerializer(ModelSerializer):
             "is_new_email_confirmed",
             "referral_code",
             "referred_by_code",
-            "avatar",
-            "name",
             "phone_number",
             "preferred_language",
         )

--- a/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
@@ -22,27 +22,26 @@ Profile = swapper.load_model("baseapp_profiles", "Profile")
 
 from baseapp_auth.password_validators import apply_password_validators
 
+
 class JWTProfileSerializer(serializers.ModelSerializer):
     """
     Serializes minimal profile data that will be attached to the JWT token as claim
     """
-    url_path = serializers.SerializerMethodField() # serializers.SlugField(required=False)
+    url_path = serializers.SlugField(required=False)
     id = serializers.SerializerMethodField() 
-    image = ThumbnailImageField(required=False, sizes={"url": (100,100)})
+    image = ThumbnailImageField(required=False, sizes={"small": (100,100)})
 
     class Meta:
         model = Profile
         fields = ("id", "name", "image", "url_path")
 
-    def get_url_path(self, profile):
-        return { 'path': profile.url_path.path}
-
     def get_id(self, profile):
         return get_obj_relay_id(profile)
 
-    def to_representation(self, instance):
-        data = super().to_representation(instance)
-        data['image'].pop('full_size')
+    def to_representation(self, profile):
+        data = super().to_representation(profile)
+        if (data['image'] != None):
+            data['image'] = data['image']['small']
         return data
 
 

--- a/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
+++ b/baseapp-auth/baseapp_auth/rest_framework/users/serializers.py
@@ -40,7 +40,7 @@ class JWTProfileSerializer(serializers.ModelSerializer):
 
     def to_representation(self, profile):
         data = super().to_representation(profile)
-        if (data['image'] != None):
+        if data['image'] is not None:
             data['image'] = data['image']['small']
         return data
 

--- a/baseapp-auth/baseapp_auth/tests/integration/test_login.py
+++ b/baseapp-auth/baseapp_auth/tests/integration/test_login.py
@@ -134,7 +134,7 @@ class TestLoginJwt(TestLoginBase):
 
         assert validated_token["id"] == user.id
         assert validated_token["email"] == user.email
-        assert validated_token["name"] == user.first_name
+        assert validated_token["profile"]["name"] == user.first_name + " " + user.last_name
 
 
 class TestLoginMfaAuthToken(TestLoginBase):

--- a/baseapp-auth/baseapp_auth/tests/integration/test_users.py
+++ b/baseapp-auth/baseapp_auth/tests/integration/test_users.py
@@ -42,27 +42,44 @@ class TestUsersRetrieve(ApiMixin):
         h.responseOk(r)
         expected = {
             "id",
+            "profile",
             "email",
             "is_email_verified",
             "email_verification_required",
             "new_email",
             "is_new_email_confirmed",
             "referral_code",
-            "avatar",
-            "name",
             "phone_number",
             "preferred_language",
         }
         actual = set(r.data.keys())
         assert expected == actual
 
+        profile_expected = {
+            "id",
+            "name",
+            "image",
+            "url_path"
+        }
+        profile_actual = set(r.data["profile"].keys())
+        assert profile_expected == profile_actual
+
     def test_object_keys_for_other_user(self, user_client):
         user = UserFactory()
         r = user_client.get(self.reverse(kwargs={"pk": user.pk}))
         h.responseOk(r)
-        expected = {"id", "avatar", "name", "phone_number"}
+        expected = {"id", "profile", "phone_number"}
         actual = set(r.data.keys())
         assert expected == actual
+
+        profile_expected = {
+            "id",
+            "name",
+            "image",
+            "url_path"
+        }
+        profile_actual = set(r.data["profile"].keys())
+        assert profile_expected == profile_actual
 
 
 class TestUsersUpdate(ApiMixin):
@@ -138,7 +155,7 @@ class TestUsersUpdate(ApiMixin):
         r = user_client.patch(self.reverse(kwargs={"pk": user_client.user.pk}), data)
         h.responseOk(r)
         user_client.user.profile.refresh_from_db()
-        assert user_client.user.profile.image is not None
+        assert bool(user_client.user.profile.image) is True
 
     def test_can_clear_avatar(self, user_client, image_djangofile):
         user_client.user.profile.image = image_djangofile
@@ -167,7 +184,7 @@ class TestUsersList(ApiMixin):
         r = user_client.get(self.reverse(query_params={"q": "John Smith"}))
         h.responseOk(r)
         assert len(r.data["results"]) == 1
-        assert r.data["results"][0]["name"] == "John"
+        assert r.data["results"][0]["profile"]["name"] == "John Smith"
 
 
 class TestUsersMe(ApiMixin):

--- a/baseapp-auth/baseapp_auth/tests/integration/test_users.py
+++ b/baseapp-auth/baseapp_auth/tests/integration/test_users.py
@@ -55,12 +55,7 @@ class TestUsersRetrieve(ApiMixin):
         actual = set(r.data.keys())
         assert expected == actual
 
-        profile_expected = {
-            "id",
-            "name",
-            "image",
-            "url_path"
-        }
+        profile_expected = {"id", "name", "image", "url_path"}
         profile_actual = set(r.data["profile"].keys())
         assert profile_expected == profile_actual
 
@@ -72,12 +67,7 @@ class TestUsersRetrieve(ApiMixin):
         actual = set(r.data.keys())
         assert expected == actual
 
-        profile_expected = {
-            "id",
-            "name",
-            "image",
-            "url_path"
-        }
+        profile_expected = {"id", "name", "image", "url_path"}
         profile_actual = set(r.data["profile"].keys())
         assert profile_expected == profile_actual
 

--- a/baseapp-auth/setup.cfg
+++ b/baseapp-auth/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = baseapp_auth
-version = 0.4.9
+version = 0.4.10
 description = BaseApp Auth
 long_description = file: README.md
 url = https://github.com/silverlogic/baseapp-backend

--- a/baseapp-profiles/baseapp_profiles/managers.py
+++ b/baseapp-profiles/baseapp_profiles/managers.py
@@ -3,7 +3,7 @@ from django.db import models
 
 class ProfileManager(models.Manager):
     def filter_user_profiles(self, user):
-        return self.filter(models.Q(members__user=user) | models.Q(owner=user))
+        return self.filter(models.Q(members__user=user) | models.Q(owner=user)).distinct()
 
     def get_if_member(self, user, **kwargs):
         if user.is_superuser:

--- a/baseapp-profiles/setup.cfg
+++ b/baseapp-profiles/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = baseapp_profiles
-version = 0.3.2
+version = 0.3.3
 description = BaseApp Profiles
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
This adds basic profile information (id, name, image, urlPath) to the JWT claims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new `JWTProfileSerializer` for improved user data serialization in JWT tokens.
	- Updated user profile retrieval to ensure unique results by eliminating duplicates.

- **Bug Fixes**
	- Adjusted the JWT token structure to include user names as part of a nested profile object.

- **Tests**
	- Enhanced test cases to reflect changes in user data structure, ensuring proper validation of profiles.

- **Chores**
	- Incremented version number from 0.4.9 to 0.4.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->