### PR TITLE
upgrade pypi publish action to v1.12.2

### DIFF
--- a/.github/workflows/publish-workflow.yml
+++ b/.github/workflows/publish-workflow.yml
@@ -31,7 +31,7 @@ jobs:
         run: python3 setup.py sdist
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.12.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: ${{ inputs.project }}/dist/

--- a/baseapp/setup.cfg
+++ b/baseapp/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = baseapp-backend
-version = 0.0.1
+version = 0.0.2
 description = BaseApp
 long_description = file: README.md
 url = https://github.com/silverlogic/baseapp-backend


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the GitHub Actions workflow for publishing to PyPI with a new action version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->