### PR TITLE
baseapp-chats: Removing chat room participants

### DIFF
--- a/baseapp-chats/baseapp_chats/graphql/object_types.py
+++ b/baseapp-chats/baseapp_chats/graphql/object_types.py
@@ -193,6 +193,7 @@ class BaseChatRoomObjectType:
             "last_message_time",
             "last_message",
             "participants",
+            "participants_count",
             "title",
             "image",
             "is_group",

--- a/baseapp-chats/baseapp_chats/utils.py
+++ b/baseapp-chats/baseapp_chats/utils.py
@@ -36,11 +36,11 @@ def send_message(
 
     from baseapp_chats.graphql.subscriptions import ChatRoomOnNewMessage
 
-    ChatRoomOnNewMessage.new_message(room_id=room_id or room.relay_id, message=message)
-
     room.last_message_time = message.created
     room.last_message = message
     room.save()
+
+    ChatRoomOnNewMessage.new_message(room_id=room_id or room.relay_id, message=message)
 
     return message
 

--- a/baseapp-chats/setup.cfg
+++ b/baseapp-chats/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = baseapp_chats
-version = 0.0.10
+version = 0.0.11
 description = BaseApp Chats
 long_description = file: README.md
 url = https://github.com/silverlogic/baseapp-backend


### PR DESCRIPTION
As a user, on the BaseApp Messages, I would like to Remove an existing member of the group, In order to avoid that person to have access to the group messages.

Original Story:  
**Acceptance Criteria 
Removing a Member**

- Given I am an admin of the group, when I select a member from the group details view, then I should have the option to remove that member from the group.

  - We should have already implemented the Remove Member option button in the Admin Permission story, but not the functionality. 

- Given I click on remove member, I should see a confirmation dialog, to make sure I want to do this action.

- Given I confirm the removal of the member, then the removed member should no longer see the group in their chat list or have access to its messages.

  - We are doing a hard delete of the group chat for that user. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced chat room participant management with ability to remove participants
	- Added participant role tracking in chat rooms
	- Improved chat room update notifications

- **Bug Fixes**
	- Streamlined participant removal process
	- Enhanced error handling for chat room operations

- **Documentation**
	- Updated GraphQL schema to provide more detailed chat room information

- **Chores**
	- Incremented package version to 0.0.11
<!-- end of auto-generated comment: release notes by coderabbit.ai -->