### PR TITLE
baseapp-chats: Fix chatroom search

### DIFF
--- a/baseapp-chats/setup.cfg
+++ b/baseapp-chats/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = baseapp_chats
-version = 0.0.9
+version = 0.0.10
 description = BaseApp Chats
 long_description = file: README.md
 url = https://github.com/silverlogic/baseapp-backend


### PR DESCRIPTION
Makes sure that the first acceptance criterium below is satisfied, i.e. that we **search the chatroom name** (and not participant names). Note that the current behaviour explained in the linked video is frontend related and will be fixed in a frontend PR.


**Description**

**Acceptance Criteria** 

- Given I am using the search bar to locate a chat room, when I type the complete name or a partial name of a chat room into the search bar, then the displayed list of chat rooms should dynamically update to show only those chat rooms whose names contain the entered text (case-insensitive match).

- And if no matching chat rooms are found, an appropriate "No results found" message should be displayed.

- It should filter the Chat List that is selected. 

**Current behavior** 
When I use the search bar in the Archive Chat list, is doesnt show chat rooms even tho they contain the entered text. It shows the empty state when no chat rooms were found.
This empty state persists even tho I clear the search bar.

[https://www.loom.com/share/7e249f5eb0ab4814a7c3544302b1f047](https://www.loom.com/share/7e249f5eb0ab4814a7c3544302b1f047)

**Approvd** 
[https://app.approvd.io/silverlogic/BA/stories/38023](https://app.approvd.io/silverlogic/BA/stories/38023)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced chat room filtering with the ability to filter by title and participant names.
  - Introduced a search parameter for more nuanced chat room queries.

- **Bug Fixes**
  - Improved error handling in the chat room filtering mechanism.

- **Tests**
  - Added new test cases for filtering chat rooms by title, including unread and archived rooms.

- **Chores**
  - Updated package version to 0.0.10.

This update provides users with improved navigation and discovery options within chat rooms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->