### PR TITLE
baseapp-chats [BA-2108]: leave group as admin

### DIFF
--- a/baseapp-chats/baseapp_chats/graphql/mutations.py
+++ b/baseapp-chats/baseapp_chats/graphql/mutations.py
@@ -222,6 +222,31 @@ class ChatRoomUpdate(RelayMutation):
     ):
         room = get_obj_from_relay_id(info, room_id)
         profile = get_obj_from_relay_id(info, profile_id)
+        is_sole_admin = (
+            ChatRoomParticipant.objects.filter(
+                profile=profile, room=room, role=ChatRoomParticipantRoles.ADMIN
+            ).exists()
+            and ChatRoomParticipant.objects.filter(
+                room=room, role=ChatRoomParticipantRoles.ADMIN
+            ).count()
+            == 1
+        )
+        is_leaving_chatroom = profile_id in remove_participants and len(remove_participants) == 1
+
+        add_participants_pks = [
+            get_pk_from_relay_id(participant) for participant in add_participants
+        ]
+
+        remove_participants_pks = [
+            get_pk_from_relay_id(participant) for participant in remove_participants
+        ]
+        participants_to_remove = ChatRoomParticipant.objects.filter(
+            profile_id__in=remove_participants_pks, room=room
+        )
+        removed_participants = list(participants_to_remove)
+
+        title = input.get("title", None)
+        image = info.context.FILES.get("image", None)
 
         if not room or not getattr(room, "is_group", False):
             return ChatRoomUpdate(
@@ -243,21 +268,6 @@ class ChatRoomUpdate(RelayMutation):
                 ]
             )
 
-        add_participants_pks = [
-            get_pk_from_relay_id(participant) for participant in add_participants
-        ]
-
-        remove_participants_pks = [
-            get_pk_from_relay_id(participant) for participant in remove_participants
-        ]
-        participants_to_remove = ChatRoomParticipant.objects.filter(
-            profile_id__in=remove_participants_pks, room=room
-        )
-        removed_participants = list(participants_to_remove)
-
-        title = input.get("title", None)
-        image = info.context.FILES.get("image", None)
-
         # Check if added participants are blocked
         if Block.objects.filter(
             Q(actor_id=profile.id, target_id__in=add_participants_pks)
@@ -278,7 +288,7 @@ class ChatRoomUpdate(RelayMutation):
                 "profile": profile,
                 "room": room,
                 "add_participants": add_participants_pks,
-                "remove_participants": remove_participants_pks,
+                "is_leaving_chatroom": is_leaving_chatroom,
                 "modify_image": image or delete_image,
                 "modify_title": title,
             },
@@ -292,10 +302,6 @@ class ChatRoomUpdate(RelayMutation):
                 ]
             )
 
-        # CHange title
-        if title is not None:
-            room.title = title
-
         # Change image
         serializer = ImageSerializer(data={"image": image})
         if not serializer.is_valid():
@@ -303,19 +309,27 @@ class ChatRoomUpdate(RelayMutation):
                 errors=[ErrorType(field="image", messages=serializer.errors["image"])]
             )
 
+        participants_to_remove.delete()
+
+        # Setting new admin if needed
+        if is_leaving_chatroom and is_sole_admin:
+            oldest_remaining_participant = (
+                ChatRoomParticipant.objects.filter(room=room).order_by("accepted_at").first()
+            )
+            if oldest_remaining_participant:
+                oldest_remaining_participant.role = ChatRoomParticipantRoles.ADMIN
+                oldest_remaining_participant.save(update_fields=["role"])
+
+        # Update room
+        # TODO: Remeber to include added participants into count when implementing that feature
+        room.participants_count = room.participants_count - len(removed_participants)
+        if title is not None:
+            room.title = title
         if image is not None:
             room.image = serializer.validated_data["image"]
         elif delete_image:
             room.image = None
-
-        # Remove participants
-        participants_to_remove.delete()
-
-        # TODO: Remeber to include added participants into count when implementing that feature
-        room.participants_count = room.participants_count - len(removed_participants)
         room.save()
-
-        # TODO: Add participants
 
         ChatRoomOnRoomUpdate.room_updated(room, removed_participants)
 

--- a/baseapp-chats/baseapp_chats/permissions.py
+++ b/baseapp-chats/baseapp_chats/permissions.py
@@ -40,7 +40,7 @@ class ChatsPermissionsBackend(BaseBackend):
     def can_modify_chatroom(self, user_obj, obj):
         if isinstance(obj, dict):
             room = obj["room"]
-            remove_participants = obj["remove_participants"]
+            is_leaving_chatroom = obj["is_leaving_chatroom"]
             add_participants = obj["add_participants"]
             current_profile = obj["profile"]
             modify_image = obj["modify_image"]
@@ -56,11 +56,12 @@ class ChatsPermissionsBackend(BaseBackend):
             if not chat_room_participant:
                 return False
 
-            is_removing_self = len(remove_participants) == 1 and str(remove_participants[0]) == str(
-                current_profile.pk
-            )
-
-            if is_removing_self and not modify_image and not modify_title and not add_participants:
+            if (
+                is_leaving_chatroom
+                and not modify_image
+                and not modify_title
+                and not add_participants
+            ):
                 return True
 
             if chat_room_participant.role != ChatRoomParticipant.ChatRoomParticipantRoles.ADMIN:


### PR DESCRIPTION
**Acceptance Criteria**

- Given I click on the "Leave Group" button in the 3 dots menu, when the action is triggered, then I should see a confirmation prompt asking if I am sure I want to leave the group.

- Given I am the sole admin in the group chat, then the confirmation dialog should inform me prompt me to select a new admin before leaving and informing me if I don't, then the most senior member will be the new admin.

- Given there are other admins besides me in the group then only display a the same confirmation dialog a normal member would have when leaving the group chat.

- Given I confirm that I want to leave the group, then I should no longer see the group in my chat list and stop receiving updates of messages on that group.

We are going to do a hard delete for that Group Chat for that user.

- Given I've left the chat room, then make the most senior member in the group the new admin.