### PR TITLE
Baseapp Activity Log - Search by user

### DIFF
--- a/baseapp/baseapp/activity_log/graphql/filters.py
+++ b/baseapp/baseapp/activity_log/graphql/filters.py
@@ -1,4 +1,5 @@
 import django_filters
+from django.db.models import Q
 
 from ..models import ActivityLog
 
@@ -8,10 +9,16 @@ class ActivityLogFilter(django_filters.FilterSet):
     created_to = django_filters.DateFilter(field_name="created_at__lte")
     user_pk = django_filters.NumberFilter(field_name="user_id")
     profile_pk = django_filters.NumberFilter(field_name="profile_id")
+    user_name = django_filters.CharFilter(method="filter_user_name")
+
+    def filter_user_name(self, queryset, name, value):
+        return queryset.filter(
+            Q(user__profile__name__icontains=value) | Q(user__email__icontains=value)
+        )
 
     class Meta:
         model = ActivityLog
-        fields = ["created_from", "created_to", "user_pk", "profile_pk"]
+        fields = ["created_from", "created_to", "user_pk", "profile_pk", "user_name"]
 
 
 class MiddlewareEventFilter(django_filters.FilterSet):

--- a/baseapp/baseapp/activity_log/graphql/queries.py
+++ b/baseapp/baseapp/activity_log/graphql/queries.py
@@ -13,5 +13,5 @@ class ActivityLogQueries:
         max_limit=100,
     )
 
-    def resolve_activity_log(self, info, visibility=None, **kwargs):
+    def resolve_activity_logs(self, info, visibility=None, **kwargs):
         return ActivityLog.objects.all()

--- a/baseapp/setup.cfg
+++ b/baseapp/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = baseapp-backend
-version = 0.0.3
+version = 0.0.4
 description = BaseApp
 long_description = file: README.md
 url = https://github.com/silverlogic/baseapp-backend


### PR DESCRIPTION
Description

As a user, on the Baseapp Activity Log,I would like to Filter Activity Logs based on users, In order to search for activites made by a specific user.

 
Acceptance Criteria 
Context
We will enable the search bar, and right now we are only going to query by user.

Business Rules

Reuse the search bar component from the Messages Epic

The label should state "Search by user"

Implement a search bar that filters out activities based on which user made that activity.

 The search should be case-insensitive, so typing “john” should return results for “John” or “john.”

The search should support partial matches, meaning typing part of a contact's name (e.g., “Jo” for “John Doe”) should filter the list to show all matching results.

If no contacts match the search query, display a 
"no activities to be displayed" empty state image

If no activity logs match the search query, the application should display a specific image or message indicating no messages to be displayed. This informs the user that there are no matching results. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added ability to filter activity logs by user name.
	- Supports case-insensitive and partial name matching.

- **Tests**
	- Added comprehensive test coverage for new user name filtering functionality.
	- Verified filtering works with different name scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->