### PR TITLE
baseapp.activity_logs: filter by date

### DIFF
--- a/baseapp/baseapp/activity_log/graphql/filters.py
+++ b/baseapp/baseapp/activity_log/graphql/filters.py
@@ -1,6 +1,7 @@
 import django_filters
-from django.db.models import Q
 from django.core.exceptions import ValidationError
+from django.db.models import Q
+
 from ..models import ActivityLog
 
 

--- a/baseapp/baseapp/activity_log/graphql/filters.py
+++ b/baseapp/baseapp/activity_log/graphql/filters.py
@@ -1,12 +1,12 @@
 import django_filters
 from django.db.models import Q
-
+from django.core.exceptions import ValidationError
 from ..models import ActivityLog
 
 
 class ActivityLogFilter(django_filters.FilterSet):
-    created_from = django_filters.DateFilter(field_name="created_at__gte")
-    created_to = django_filters.DateFilter(field_name="created_at__lte")
+    created_from = django_filters.DateFilter(field_name="created_at", lookup_expr="gte")
+    created_to = django_filters.DateFilter(field_name="created_at", lookup_expr="lte")
     user_pk = django_filters.NumberFilter(field_name="user_id")
     profile_pk = django_filters.NumberFilter(field_name="profile_id")
     user_name = django_filters.CharFilter(method="filter_user_name")
@@ -15,6 +15,15 @@ class ActivityLogFilter(django_filters.FilterSet):
         return queryset.filter(
             Q(user__profile__name__icontains=value) | Q(user__email__icontains=value)
         )
+
+    def filter_queryset(self, queryset):
+        created_from = self.data.get("created_from")
+        created_to = self.data.get("created_to")
+
+        if created_from and created_to and created_from > created_to:
+            raise ValidationError("`created_from` must be earlier than or equal to `created_to`.")
+
+        return super().filter_queryset(queryset)
 
     class Meta:
         model = ActivityLog

--- a/baseapp/baseapp/activity_log/graphql/filters.py
+++ b/baseapp/baseapp/activity_log/graphql/filters.py
@@ -5,8 +5,8 @@ from ..models import ActivityLog
 
 
 class ActivityLogFilter(django_filters.FilterSet):
-    created_from = django_filters.DateFilter(field_name="created_at", lookup_expr="gte")
-    created_to = django_filters.DateFilter(field_name="created_at", lookup_expr="lte")
+    created_from = django_filters.DateFilter(field_name="created_at", lookup_expr="date__gte")
+    created_to = django_filters.DateFilter(field_name="created_at", lookup_expr="date__lte")
     user_pk = django_filters.NumberFilter(field_name="user_id")
     profile_pk = django_filters.NumberFilter(field_name="profile_id")
     user_name = django_filters.CharFilter(method="filter_user_name")
@@ -22,7 +22,6 @@ class ActivityLogFilter(django_filters.FilterSet):
 
         if created_from and created_to and created_from > created_to:
             raise ValidationError("`created_from` must be earlier than or equal to `created_to`.")
-
         return super().filter_queryset(queryset)
 
     class Meta:

--- a/baseapp/baseapp/activity_log/tests/test_graphql_queries.py
+++ b/baseapp/baseapp/activity_log/tests/test_graphql_queries.py
@@ -408,4 +408,7 @@ def test_invalid_date_range_created_from_after_created_to(django_user_client, gr
     content = response.json()
     assert "errors" in content
     error_messages = [error["message"] for error in content["errors"]]
-    assert any("`created_from` must be earlier than or equal to `created_to`." in message for message in error_messages)
+    assert any(
+        "`created_from` must be earlier than or equal to `created_to`." in message
+        for message in error_messages
+    )

--- a/baseapp/baseapp/activity_log/tests/test_graphql_queries.py
+++ b/baseapp/baseapp/activity_log/tests/test_graphql_queries.py
@@ -1,6 +1,6 @@
-import pghistory
 import datetime
 
+import pghistory
 import pytest
 import swapper
 from baseapp_profiles.tests.factories import ProfileFactory
@@ -382,11 +382,10 @@ def test_filter_by_partial_match(django_user_client, graphql_user_client):
     assert len(content["data"]["activityLogs"]["edges"]) == 1
 
 
-
 def test_invalid_date_range_created_from_after_created_to(django_user_client, graphql_user_client):
     now = datetime.date.today()
-    created_from = now + datetime.timedelta(days=1)  
-    created_to = now - datetime.timedelta(days=1)    
+    created_from = now + datetime.timedelta(days=1)
+    created_to = now - datetime.timedelta(days=1)
 
     response = graphql_user_client(
         """
@@ -410,5 +409,3 @@ def test_invalid_date_range_created_from_after_created_to(django_user_client, gr
     assert "errors" in content
     error_messages = [error["message"] for error in content["errors"]]
     assert any("`created_from` must be earlier than or equal to `created_to`." in message for message in error_messages)
-
-


### PR DESCRIPTION
Description

As a user, on the Baseapp Activity Log,I would like to Filter activity entries by date, In order to quickly search for activities made in specific periods of time.

 
Acceptance Criteria 
Context
The objective of this story is to implement a filter that reduces the amount of activity logs displayed in order to search for logs in a specific period of time. 

Business Rules

Given I am a user searching for specific activites, when I use the date filters, Then the system shall display all activity logs that occurred from the start date through the end date, inclusive of both dates.

The system must provide a user-friendly interface for selecting a start date and an end date for filtering the activity logs.

Make sure the component complies with the current implemented Design System

The date selection tool must prevent the user from selecting an end date that is earlier than the start date.

The filtered activity log view must include a clear indicator of the date range currently being viewed per figma

Users must have the ability to clear the selected date range to return to viewing all activity logs without applying the date filter individually

The filter must apply after a date has been set, even if it's only 1 date that has been selected

The user should not be allowed to select future dates. 

Design Link: https://www.figma.com/design/XRD6wSl1m8Kz6XUcAy5CLp/BaseApp---WEB?node-id=3738-46140&t=0SETItr5R9RznbuZ-4 
Demo
https://www.loom.com/share/dec2d3ab87984a85acc52ccce6f20a81