### PR TITLE
baseapp-auth: Remove short name

### DIFF
--- a/baseapp-auth/baseapp_auth/graphql/object_types.py
+++ b/baseapp-auth/baseapp_auth/graphql/object_types.py
@@ -48,7 +48,6 @@ if apps.is_installed("baseapp.activity_log"):
 class AbstractUserObjectType(*inheritances, object):
     is_authenticated = graphene.Boolean()
     full_name = graphene.String()
-    short_name = graphene.String()
 
     first_name = graphene.String(deprecation_reason="Deprecated in favor of fullName and shortName")
     last_name = graphene.String(deprecation_reason="Deprecated in favor of fullName and shortName")
@@ -72,7 +71,6 @@ class AbstractUserObjectType(*inheritances, object):
             "first_name",
             "last_name",
             "full_name",
-            "short_name",
             "email",
             "phone_number",
             "is_superuser",
@@ -106,9 +104,6 @@ class AbstractUserObjectType(*inheritances, object):
 
     def resolve_full_name(self, *args, **kwargs):
         return self.profile.name
-
-    def resolve_short_name(self, *args, **kwargs):
-        return self.get_short_name()
 
     def resolve_email(self, info):
         return view_user_private_field(self, info, "email")

--- a/baseapp-auth/baseapp_auth/models.py
+++ b/baseapp-auth/baseapp_auth/models.py
@@ -89,9 +89,6 @@ class AbstractUser(PermissionsMixin, AbstractBaseUser, use_relay_model(), use_pr
     def __str__(self):
         return self.get_full_name()
 
-    def get_short_name(self):
-        return self.email
-
     def get_full_name(self):
         names = [self.first_name, self.last_name]
         full_name = " ".join([name for name in names if name]).strip()

--- a/baseapp-auth/baseapp_auth/tests/unit/test_users.py
+++ b/baseapp-auth/baseapp_auth/tests/unit/test_users.py
@@ -19,11 +19,6 @@ def test_user_str():
     assert str(user) == "john@gmail.com"
 
 
-def test_user_get_short_name():
-    user = User(email="john@gmail.com")
-    assert user.get_short_name() == "john@gmail.com"
-
-
 def test_user_get_full_name():
     user = User(first_name="John", last_name="Doe", email="john@gmail.com")
     assert user.get_full_name() == "John Doe"


### PR DESCRIPTION
The short name is currently equal to the email address of a user, so the graphql request
```
allProfiles {
   edges {
      node {
         owner {
            shortName
         }
      }
   }
}
```
produces a list of email addresses of signed up users (for any user who is authenticated). Since we do not want to expose email addresses, this removes `shortName` (it is not used on the frontend).