### PR TITLE
baseapp-profiles[BA-2244]: edit/generate username for Profile

### DIFF
--- a/baseapp-profiles/baseapp_profiles/tests/test_graphql_mutations_update.py
+++ b/baseapp-profiles/baseapp_profiles/tests/test_graphql_mutations_update.py
@@ -111,8 +111,8 @@ def test_owner_can_update_profile_url_path(django_user_client, graphql_user_clie
 
 
 def test_owner_can_update_profile_url_path_already_in_use(django_user_client, graphql_user_client):
-    url_path = "new-path"
-    URLPathFactory(path=url_path)
+    url_path = "existingpath"
+    URLPathFactory(path=f"/{url_path}")
     profile = ProfileFactory(owner=django_user_client.user)
 
     response = graphql_user_client(
@@ -120,9 +120,10 @@ def test_owner_can_update_profile_url_path_already_in_use(django_user_client, gr
         variables={"input": {"id": profile.relay_id, "urlPath": url_path}},
     )
     content = response.json()
+    print(content)
     assert (
         content["data"]["profileUpdate"]["errors"][0]["messages"][0]
-        == "URL path already in use, please choose another one"
+        == "Username already in use, suggested username: /existingpath1"
     )
 
 

--- a/baseapp-profiles/setup.cfg
+++ b/baseapp-profiles/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = baseapp_profiles
-version = 0.3.12
+version = 0.3.13
 description = BaseApp Profiles
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/baseapp/baseapp_organizations/tests/test_graphql_mutations_create.py
+++ b/baseapp/baseapp_organizations/tests/test_graphql_mutations_create.py
@@ -53,4 +53,4 @@ def test_user_can_create_organization(graphql_user_client):
     )
     organization = Organization.objects.get()
     assert organization.profile.name == "my organization"
-    assert organization.profile.url_path.path == "my-organization"
+    assert organization.profile.url_path.path == "/myorganization"


### PR DESCRIPTION
**Acceptance Criteria 
Context**
Even though the username field exists, right now we don't have any way for users to setup their username in BA. And they are important for the different social feature that we have.

**Business Rules - Automatic Username Creation**

- Given I have successfully sign up and my user is created, automatically create a username using the name. (no spaces)
- If the generated username already exists, append a number at the end, incrementing the number until a unique username is established.
- The username must be a minimum of 8 characters long. If the name is shorter than 8 characters, append random digits until it meets the requirement.
- Users should not contain special characters

**Business Rules - Edit Username**

- Parse slashes on username and profile page so that the user doesn't have to put a "/" on its user to be used in the paths.
- *Include Slashes on the URL path in the BE
- Validate username input to check for the rules set up for user creation
- Given the user inputs a username that is already in use, suggest 1 other username.

**Functional Requirements**

- The system must automatically generate a username upon successful signup.
- The system must check the uniqueness of the generated username against the existing usernames in the database

**Approvd**
https://app.approvd.io/silverlogic/BA/stories/39057 