### PR TITLE
baseapp.activity_logs: add PERM_VIEW_NODE_DIFF permission

### DIFF
--- a/baseapp/baseapp/activity_log/permissions.py
+++ b/baseapp/baseapp/activity_log/permissions.py
@@ -17,6 +17,7 @@ class ActivityLogPermissionsBackend(BaseBackend):
         PERM_LIST_PROFILE,
         PERM_LIST_NODE,
         PERM_VIEW,
+        PERM_VIEW_NODE_DIFF,
     }
 
     def has_perm(self, user_obj, perm, obj=None):


### PR DESCRIPTION
add PERM_VIEW_NODE_DIFF to the activity log
In the template, custom permission has been added to activity log