### PR TITLE
baseapp_pages: fix tests and permissions

### DIFF
--- a/baseapp/baseapp_pages/graphql/mutations.py
+++ b/baseapp/baseapp_pages/graphql/mutations.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 from baseapp_core.graphql import (
+    DeleteNode,
     SerializerMutation,
     get_pk_from_relay_id,
     login_required,
@@ -16,6 +17,7 @@ from ..models import URLPath
 
 Page = swapper.load_model("baseapp_pages", "Page")
 PageObjectType = Page.get_graphql_object_type()
+page_app_label = Page._meta.app_label
 
 
 class PageSerializer(serializers.ModelSerializer):
@@ -64,7 +66,7 @@ class PageCreate(SerializerMutation):
     @classmethod
     @login_required
     def mutate_and_get_payload(cls, root, info, **input):
-        if not info.context.user.has_perm("baseapp_pages.add_page"):
+        if not info.context.user.has_perm(f"{page_app_label}.add_page"):
             raise PermissionError(_("You don't have permission to create a page"))
 
         return super().mutate_and_get_payload(root, info, **input)
@@ -91,7 +93,7 @@ class PageEdit(SerializerMutation):
     def get_serializer_kwargs(cls, root, info, **input):
         pk = get_pk_from_relay_id(input.get("id"))
         instance = Page.objects.get(pk=pk)
-        if not info.context.user.has_perm("baseapp_pages.change_page", instance):
+        if not info.context.user.has_perm(f"{page_app_label}.change_page", instance):
             raise PermissionError(_("You don't have permission to edit this page"))
         return {
             "instance": instance,
@@ -117,3 +119,4 @@ class PageEdit(SerializerMutation):
 class PagesMutations(object):
     page_create = PageCreate.Field()
     page_edit = PageEdit.Field()
+    page_delete = DeleteNode.Field()

--- a/baseapp/baseapp_pages/graphql/object_types.py
+++ b/baseapp/baseapp_pages/graphql/object_types.py
@@ -14,6 +14,7 @@ from baseapp_pages.models import AbstractPage, Metadata, URLPath
 from ..meta import AbstractMetadataObjectType
 
 Page = swapper.load_model("baseapp_pages", "Page")
+page_app_label = Page._meta.app_label
 PageStatusEnum = graphene.Enum.from_enum(Page.PageStatus)
 
 
@@ -62,7 +63,7 @@ class URLPathNode(DjangoObjectType):
 
     def resolve_target(self, info, **kwargs):
         if isinstance(self.target, AbstractPage):
-            if not info.context.user.has_perm("baseapp_pages.view_page", self.target):
+            if not info.context.user.has_perm(f"{page_app_label}.view_page", self.target):
                 return None
         return self.target
 
@@ -88,7 +89,7 @@ class BasePageObjectType:
     @classmethod
     def get_node(cls, info, id):
         node = super().get_node(info, id)
-        if not info.context.user.has_perm("baseapp_pages.view_page", node):
+        if not info.context.user.has_perm(f"{page_app_label}.view_page", node):
             return None
         return node
 

--- a/baseapp/baseapp_pages/permissions.py
+++ b/baseapp/baseapp_pages/permissions.py
@@ -2,11 +2,12 @@ import swapper
 from django.contrib.auth.backends import BaseBackend
 
 Page = swapper.load_model("baseapp_pages", "Page")
+page_app_label = Page._meta.app_label
 
 
 class PagesPermissionsBackend(BaseBackend):
     def has_perm(self, user_obj, perm, obj=None):
-        if perm == "baseapp_pages.view_page":
+        if perm == f"{page_app_label}.view_page":
             if not obj:
                 # Anyone can view a page
                 return True
@@ -15,9 +16,9 @@ class PagesPermissionsBackend(BaseBackend):
                     return True
                 else:
                     # Only users who has change permission can view unpublished pages
-                    return user_obj.has_perm("baseapp_pages.change_page", obj)
+                    return user_obj.has_perm(f"{page_app_label}.change_page", obj)
 
-        if perm in ["baseapp_pages.change_page", "baseapp_pages.delete_page"]:
+        if perm in [f"{page_app_label}.change_page", f"{page_app_label}.delete_page"]:
             if user_obj.is_authenticated and isinstance(obj, Page):
                 # Owner can change and delete their own pages
                 if obj.user_id == user_obj.id:

--- a/baseapp/baseapp_pages/tests/test_delete_mutation.py
+++ b/baseapp/baseapp_pages/tests/test_delete_mutation.py
@@ -7,11 +7,12 @@ from .factories import PageFactory
 pytestmark = pytest.mark.django_db
 
 Page = swapper.load_model("baseapp_pages", "Page")
+page_app_label = Page._meta.app_label
 
 
 DELETE_MUTATION_QUERY = """
     mutation PageDelete($input: DeleteNodeInput!) {
-        deleteNode(input: $input) {
+        pageDelete(input: $input) {
             deletedID
         }
     }
@@ -51,7 +52,7 @@ def test_superuser_can_delete_page(django_user_client, graphql_user_client):
 
     content = response.json()
 
-    assert content["data"]["deleteNode"]["deletedID"] == page.relay_id
+    assert content["data"]["pageDelete"]["deletedID"] == page.relay_id
     assert not Page.objects.exists()
 
 
@@ -69,12 +70,12 @@ def test_owner_can_delete_page(django_user_client, graphql_user_client):
 
     content = response.json()
 
-    assert content["data"]["deleteNode"]["deletedID"] == page.relay_id
+    assert content["data"]["pageDelete"]["deletedID"] == page.relay_id
     assert not Page.objects.exists()
 
 
 def test_user_with_permission_can_delete_page(django_user_client, graphql_user_client):
-    perm = Permission.objects.get(content_type__app_label="baseapp_pages", codename="delete_page")
+    perm = Permission.objects.get(content_type__app_label=page_app_label, codename="delete_page")
     django_user_client.user.user_permissions.add(perm)
 
     page = PageFactory()
@@ -90,5 +91,5 @@ def test_user_with_permission_can_delete_page(django_user_client, graphql_user_c
 
     content = response.json()
 
-    assert content["data"]["deleteNode"]["deletedID"] == page.relay_id
+    assert content["data"]["pageDelete"]["deletedID"] == page.relay_id
     assert not Page.objects.exists()

--- a/baseapp/baseapp_pages/tests/test_edit_mutation.py
+++ b/baseapp/baseapp_pages/tests/test_edit_mutation.py
@@ -8,6 +8,7 @@ from .utils import make_text_into_quill
 pytestmark = pytest.mark.django_db
 
 Page = swapper.load_model("baseapp_pages", "Page")
+page_app_label = Page._meta.app_label
 
 
 EDIT_MUTATION_QUERY = """
@@ -98,7 +99,7 @@ def test_owner_can_edit_page(django_user_client, graphql_user_client):
 
 
 def test_user_with_permission_can_edit_page(django_user_client, graphql_user_client):
-    perm = Permission.objects.get(content_type__app_label="baseapp_pages", codename="change_page")
+    perm = Permission.objects.get(content_type__app_label=page_app_label, codename="change_page")
     django_user_client.user.user_permissions.add(perm)
 
     page = PageFactory(

--- a/baseapp/baseapp_pages/tests/test_get_queries.py
+++ b/baseapp/baseapp_pages/tests/test_get_queries.py
@@ -7,6 +7,7 @@ from .utils import make_text_into_quill
 pytestmark = pytest.mark.django_db
 
 Page = swapper.load_model("baseapp_pages", "Page")
+page_app_label = Page._meta.app_label
 
 GET_PAGE_BY_PATH = """
     query Page($path: String!) {
@@ -262,15 +263,15 @@ def test_owner_can_change_page(django_user_client, graphql_user_client):
     )
 
     response = graphql_user_client(
-        query="""
-            query Page($id: ID!) {
-                page(id: $id) {
+        query=f"""
+            query Page($id: ID!) {{
+                page(id: $id) {{
                     canChange: hasPerm(perm: "change")
                     canDelete: hasPerm(perm: "delete")
-                    canChangeFull: hasPerm(perm: "baseapp_pages.change_page")
-                    canDeleteFull: hasPerm(perm: "baseapp_pages.delete_page")
-                }
-            }
+                    canChangeFull: hasPerm(perm: "{page_app_label}.change_page")
+                    canDeleteFull: hasPerm(perm: "{page_app_label}.delete_page")
+                }}
+            }}
         """,
         variables={"id": page.relay_id},
     )


### PR DESCRIPTION
fix baseapp_pages tests and permissions by using app_label instead of hardcoded baseapp_pages