### PR TITLE
Bugfix: Freezing social-auth-app-django version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -79,6 +79,7 @@ socialauth =
     hashids == 1.3.1
     rest-social-auth >= 8.1.0
     social-auth-core == 4.5.4
+    social-auth-app-django == 5.4.3
 pdf =
     pypdf == 5.6.0
 


### PR DESCRIPTION
The new release 5.5 is not compatible with Django 4.2. Since Django 4.2 will be maintained until December 2026, we decided to freeze the library at version 5.4.3 to keep BA compatible with Django 4.2.
