### PR TITLE
Feature/ba 2617 be safety check issue pointing to the httpretty package

### DIFF
--- a/baseapp_auth/tests/integration/test_change_email.py
+++ b/baseapp_auth/tests/integration/test_change_email.py
@@ -79,7 +79,7 @@ class TestChangeEmailConfirm(ApiMixin):
     @override_settings(
         BA_AUTH_CHANGE_EMAIL_CONFIRM_TOKEN_EXPIRATION_TIME_DELTA=timedelta(seconds=1)
     )
-    def test_guest_cant_confirm_with_expired_token(self, client, data, deep_link_mock_success):
+    def test_guest_cant_confirm_with_expired_token(self, client, data):
         time.sleep(1.1)
         r = client.post(self.reverse(), data)
         h.responseBadRequest(r)

--- a/baseapp_auth/tests/integration/test_confirm_email.py
+++ b/baseapp_auth/tests/integration/test_confirm_email.py
@@ -34,22 +34,22 @@ class TestConfirmEmailRequest(ApiMixin):
         h.responseBadRequest(r)
 
     @override_settings(BA_AUTH_CONFIRM_EMAIL_TOKEN_EXPIRATION_TIME_DELTA=timedelta(minutes=5))
-    def test_user_can_request(self, user_client, data, deep_link_mock_success):
+    def test_user_can_request(self, user_client, data):
         r = user_client.put(self.reverse(kwargs={"pk": self.user.pk}), data)
         h.responseOk(r)
 
     @override_settings(BA_AUTH_CONFIRM_EMAIL_TOKEN_EXPIRATION_TIME_DELTA=timedelta(seconds=1))
-    def test_user_cant_request_with_expired_token(self, user_client, data, deep_link_mock_success):
+    def test_user_cant_request_with_expired_token(self, user_client, data):
         time.sleep(1.1)
         r = user_client.put(self.reverse(kwargs={"pk": self.user.pk}), data)
         h.responseBadRequest(r)
 
-    def test_user_can_request_when_deep_link_errors(self, user_client, data, deep_link_mock_error):
+    def test_user_can_request_when_deep_link_errors(self, user_client, data):
         r = user_client.put(self.reverse(kwargs={"pk": self.user.pk}), data)
         h.responseOk(r)
 
     @override_settings(BA_AUTH_CONFIRM_EMAIL_TOKEN_EXPIRATION_TIME_DELTA=timedelta(minutes=5))
-    def test_sets_user_is_email_verified(self, user_client, data, deep_link_mock_success):
+    def test_sets_user_is_email_verified(self, user_client, data):
         assert not self.user.is_email_verified
         r = user_client.put(self.reverse(kwargs={"pk": self.user.pk}), data)
         h.responseOk(r)
@@ -57,7 +57,7 @@ class TestConfirmEmailRequest(ApiMixin):
         assert self.user.is_email_verified
 
     @override_settings(BA_AUTH_CONFIRM_EMAIL_TOKEN_EXPIRATION_TIME_DELTA=timedelta(seconds=1))
-    def test_user_cant_varify_with_expired_token(self, user_client, data, deep_link_mock_success):
+    def test_user_cant_varify_with_expired_token(self, user_client, data):
         assert not self.user.is_email_verified
         time.sleep(1.1)
         r = user_client.put(self.reverse(kwargs={"pk": self.user.pk}), data)

--- a/baseapp_cloudflare_stream_field/tests/fixtures.py
+++ b/baseapp_cloudflare_stream_field/tests/fixtures.py
@@ -1,8 +1,7 @@
-import json
 from unittest.mock import patch
 
-import httpretty
 import pytest
+import responses
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 
@@ -10,13 +9,10 @@ from baseapp_cloudflare_stream_field.stream import StreamClient
 from testproject.testapp.models import Post
 
 
-@pytest.fixture
-def use_httpretty():
-    httpretty.enable()
-    httpretty.HTTPretty.allow_net_connect = False
-    yield
-    httpretty.disable()
-    httpretty.reset()
+@pytest.fixture(autouse=True)
+def responses_mock():
+    with responses.RequestsMock() as r:
+        yield r
 
 
 @pytest.fixture
@@ -87,216 +83,135 @@ def setup_video_ready_with_error(video_uid):
 
 
 @pytest.fixture
-def mock_get_video_data(use_httpretty, account_id, video_uid):
-    httpretty.register_uri(
-        httpretty.GET,
+def mock_get_video_data(responses_mock, account_id, video_uid):
+    responses_mock.add(
+        responses.GET,
         f"https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/{video_uid}",
-        body=json.dumps(
-            {
-                "result": {
-                    "uid": video_uid,
-                    "preview": f"https://customer-f33zs165nr7gyfy4.cloudflarestream.com/{video_uid}/watch",
-                    "thumbnail": f"https://customer-f33zs165nr7gyfy4.cloudflarestream.com/{video_uid}/thumbnails/thumbnail.jpg",
-                    "readyToStream": True,
-                    "status": {"state": "ready"},
-                    "meta": {
-                        "downloaded-from": "https://storage.googleapis.com/stream-example-bucket/video.mp4",
-                        "name": "My First Stream Video",
-                    },
-                    "created": "2020-10-16T20:20:17.872170843Z",
-                    "clippedFrom": None,
-                    "size": 9032701,
+        json={
+            "result": {
+                "uid": video_uid,
+                "preview": f"https://customer-f33zs165nr7gyfy4.cloudflarestream.com/{video_uid}/watch",
+                "thumbnail": f"https://customer-f33zs165nr7gyfy4.cloudflarestream.com/{video_uid}/thumbnails/thumbnail.jpg",
+                "readyToStream": True,
+                "status": {"state": "ready"},
+                "meta": {
+                    "downloaded-from": "https://storage.googleapis.com/stream-example-bucket/video.mp4",
+                    "name": "My First Stream Video",
                 },
-                "success": True,
-                "errors": [],
-                "messages": [],
-            }
-        ),
+                "created": "2020-10-16T20:20:17.872170843Z",
+                "clippedFrom": None,
+                "size": 9032701,
+            },
+            "success": True,
+            "errors": [],
+            "messages": [],
+        },
     )
 
 
 @pytest.fixture
-def mock_upload_via_link(use_httpretty, account_id, video_uid):
-    httpretty.register_uri(
-        httpretty.POST,
+def mock_upload_via_link(responses_mock, account_id, video_uid):
+    responses_mock.add(
+        responses.POST,
         f"https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/copy",
-        body=json.dumps(
-            {
-                "result": {
-                    "uid": video_uid,
-                    "preview": f"https://customer-f33zs165nr7gyfy4.cloudflarestream.com/{video_uid}/watch",
-                    "thumbnail": f"https://customer-f33zs165nr7gyfy4.cloudflarestream.com/{video_uid}/thumbnails/thumbnail.jpg",
-                    "readyToStream": True,
-                    "status": {"state": "ready"},
-                    "meta": {
-                        "downloaded-from": "https://storage.googleapis.com/stream-example-bucket/video.mp4",
-                        "name": "My First Stream Video",
-                    },
-                    "created": "2020-10-16T20:20:17.872170843Z",
-                    "size": 9032701,
+        json={
+            "result": {
+                "uid": video_uid,
+                "preview": f"https://customer-f33zs165nr7gyfy4.cloudflarestream.com/{video_uid}/watch",
+                "thumbnail": f"https://customer-f33zs165nr7gyfy4.cloudflarestream.com/{video_uid}/thumbnails/thumbnail.jpg",
+                "readyToStream": True,
+                "status": {"state": "ready"},
+                "meta": {
+                    "downloaded-from": "https://storage.googleapis.com/stream-example-bucket/video.mp4",
+                    "name": "My First Stream Video",
                 },
-                "success": True,
-                "errors": [],
-                "messages": [],
-            }
-        ),
+                "created": "2020-10-16T20:20:17.872170843Z",
+                "size": 9032701,
+            },
+            "success": True,
+            "errors": [],
+            "messages": [],
+        },
     )
 
 
 @pytest.fixture
-def mock_update_video_data(use_httpretty, account_id, video_uid):
-    httpretty.register_uri(
-        httpretty.POST,
+def mock_update_video_data(responses_mock, account_id, video_uid):
+    responses_mock.add(
+        responses.POST,
         f"https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/{video_uid}",
-        body=json.dumps(
-            {
-                "result": {
-                    "uid": video_uid,
-                    "preview": f"https://customer-f33zs165nr7gyfy4.cloudflarestream.com/{video_uid}/watch",
-                    "thumbnail": f"https://customer-f33zs165nr7gyfy4.cloudflarestream.com/{video_uid}/thumbnails/thumbnail.jpg",
-                    "readyToStream": True,
-                    "status": {"state": "ready"},
-                    "meta": {
-                        "downloaded-from": "https://storage.googleapis.com/stream-example-bucket/video.mp4",
-                        "name": "My First Stream Video",
-                    },
-                    "created": "2020-10-16T20:20:17.872170843Z",
-                    "size": 9032701,
+        json={
+            "result": {
+                "uid": video_uid,
+                "preview": f"https://customer-f33zs165nr7gyfy4.cloudflarestream.com/{video_uid}/watch",
+                "thumbnail": f"https://customer-f33zs165nr7gyfy4.cloudflarestream.com/{video_uid}/thumbnails/thumbnail.jpg",
+                "readyToStream": True,
+                "status": {"state": "ready"},
+                "meta": {
+                    "downloaded-from": "https://storage.googleapis.com/stream-example-bucket/video.mp4",
+                    "name": "My First Stream Video",
                 },
-                "success": True,
-                "errors": [],
-                "messages": [],
-            }
-        ),
+                "created": "2020-10-16T20:20:17.872170843Z",
+                "size": 9032701,
+            },
+            "success": True,
+            "errors": [],
+            "messages": [],
+        },
     )
 
 
 @pytest.fixture
-def mock_upload_caption_file(use_httpretty, account_id, video_uid):
-    httpretty.register_uri(
-        httpretty.PUT,
+def mock_upload_caption_file(responses_mock, account_id, video_uid):
+    responses_mock.add(
+        responses.PUT,
         f"https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/{video_uid}/captions/en",
-        body=json.dumps(
-            {
-                "result": {
-                    "uid": video_uid,
-                    "preview": f"https://customer-f33zs165nr7gyfy4.cloudflarestream.com/{video_uid}/watch",
-                    "thumbnail": f"https://customer-f33zs165nr7gyfy4.cloudflarestream.com/{video_uid}/thumbnails/thumbnail.jpg",
-                    "readyToStream": True,
-                    "status": {"state": "ready"},
-                    "meta": {
-                        "downloaded-from": "https://storage.googleapis.com/stream-example-bucket/video.mp4",
-                        "name": "My First Stream Video",
-                    },
-                    "created": "2020-10-16T20:20:17.872170843Z",
-                    "size": 9032701,
+        json={
+            "result": {
+                "uid": video_uid,
+                "preview": f"https://customer-f33zs165nr7gyfy4.cloudflarestream.com/{video_uid}/watch",
+                "thumbnail": f"https://customer-f33zs165nr7gyfy4.cloudflarestream.com/{video_uid}/thumbnails/thumbnail.jpg",
+                "readyToStream": True,
+                "status": {"state": "ready"},
+                "meta": {
+                    "downloaded-from": "https://storage.googleapis.com/stream-example-bucket/video.mp4",
+                    "name": "My First Stream Video",
                 },
-                "success": True,
-                "errors": [],
-                "messages": [],
-            }
-        ),
+                "created": "2020-10-16T20:20:17.872170843Z",
+                "size": 9032701,
+            },
+            "success": True,
+            "errors": [],
+            "messages": [],
+        },
     )
 
 
 @pytest.fixture
-def mock_delete_video_data(use_httpretty, account_id, video_uid):
-    httpretty.register_uri(
-        httpretty.DELETE,
+def mock_delete_video_data(responses_mock, account_id, video_uid):
+    responses_mock.add(
+        responses.DELETE,
         f"https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/{video_uid}",
     )
 
 
 @pytest.fixture
-def mock_list_videos(use_httpretty, account_id, video_uid):
-    httpretty.register_uri(
-        httpretty.GET,
+def mock_list_videos(responses_mock, account_id, video_uid):
+    responses_mock.add(
+        responses.GET,
         f"https://api.cloudflare.com/client/v4/accounts/{account_id}/stream",
-        body=json.dumps(
-            {
-                "errors": [],
-                "messages": [],
-                "success": True,
-                "result": [
-                    {
-                        "allowedOrigins": ["example.com"],
-                        "created": "2014-01-02T02:20:00Z",
-                        "creator": "creator-id_abcde12345",
-                        "duration": 0,
-                        "input": {"height": 0, "width": 0},
-                        "liveInput": "fc0a8dc887b16759bfd9ad922230a014",
-                        "maxDurationSeconds": 1,
-                        "meta": {"name": "video12345.mp4"},
-                        "modified": "2014-01-02T02:20:00Z",
-                        "playback": {
-                            "dash": "https://customer-m033z5x00ks6nunl.cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/manifest/video.mpd",
-                            "hls": "https://customer-m033z5x00ks6nunl.cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/manifest/video.m3u8",
-                        },
-                        "preview": "https://customer-m033z5x00ks6nunl.cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/watch",
-                        "readyToStream": True,
-                        "readyToStreamAt": "2014-01-02T02:20:00Z",
-                        "requireSignedURLs": True,
-                        "scheduledDeletion": "2014-01-02T02:20:00Z",
-                        "size": 4190963,
-                        "status": {
-                            "errorReasonCode": "ERR_NON_VIDEO",
-                            "errorReasonText": "The file was not recognized as a valid video file.",
-                            "pctComplete": "string",
-                            "state": "inprogress",
-                        },
-                        "thumbnail": "https://customer-m033z5x00ks6nunl.cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/thumbnails/thumbnail.jpg",
-                        "thumbnailTimestampPct": 0.529241,
-                        "uid": video_uid,
-                        "uploadExpiry": "2014-01-02T02:20:00Z",
-                        "uploaded": "2014-01-02T02:20:00Z",
-                        "watermark": {
-                            "created": "2014-01-02T02:20:00Z",
-                            "downloadedFrom": "https://company.com/logo.png",
-                            "height": 0,
-                            "name": "Marketing Videos",
-                            "opacity": 0.75,
-                            "padding": 0.1,
-                            "position": "center",
-                            "scale": 0.1,
-                            "size": 29472,
-                            "uid": "ea95132c15732412d22c1476fa83f27a",
-                            "width": 0,
-                        },
-                    }
-                ],
-                "range": 1000,
-                "total": 35586,
-            }
-        ),
-    )
-
-
-@pytest.fixture
-def mock_download_video(use_httpretty, account_id, video_uid):
-    httpretty.register_uri(
-        httpretty.POST,
-        f"https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/{video_uid}/downloads",
-        body=json.dumps({"errors": [], "messages": [], "success": True, "result": {}}),
-    )
-
-
-@pytest.fixture
-def mock_clip_video(use_httpretty, account_id, clipped_video_uid, video_uid):
-    httpretty.register_uri(
-        httpretty.POST,
-        f"https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/clip",
-        body=json.dumps(
-            {
-                "errors": [],
-                "messages": [],
-                "success": True,
-                "result": {
-                    "uid": clipped_video_uid,
+        json={
+            "errors": [],
+            "messages": [],
+            "success": True,
+            "result": [
+                {
                     "allowedOrigins": ["example.com"],
-                    "clippedFromVideoUID": video_uid,
                     "created": "2014-01-02T02:20:00Z",
                     "creator": "creator-id_abcde12345",
-                    "endTimeSeconds": 0,
+                    "duration": 0,
+                    "input": {"height": 0, "width": 0},
+                    "liveInput": "fc0a8dc887b16759bfd9ad922230a014",
                     "maxDurationSeconds": 1,
                     "meta": {"name": "video12345.mp4"},
                     "modified": "2014-01-02T02:20:00Z",
@@ -305,12 +220,81 @@ def mock_clip_video(use_httpretty, account_id, clipped_video_uid, video_uid):
                         "hls": "https://customer-m033z5x00ks6nunl.cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/manifest/video.m3u8",
                     },
                     "preview": "https://customer-m033z5x00ks6nunl.cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/watch",
+                    "readyToStream": True,
+                    "readyToStreamAt": "2014-01-02T02:20:00Z",
                     "requireSignedURLs": True,
-                    "startTimeSeconds": 0,
-                    "status": "inprogress",
+                    "scheduledDeletion": "2014-01-02T02:20:00Z",
+                    "size": 4190963,
+                    "status": {
+                        "errorReasonCode": "ERR_NON_VIDEO",
+                        "errorReasonText": "The file was not recognized as a valid video file.",
+                        "pctComplete": "string",
+                        "state": "inprogress",
+                    },
+                    "thumbnail": "https://customer-m033z5x00ks6nunl.cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/thumbnails/thumbnail.jpg",
                     "thumbnailTimestampPct": 0.529241,
-                    "watermark": {"uid": "ea95132c15732412d22c1476fa83f27a"},
+                    "uid": video_uid,
+                    "uploadExpiry": "2014-01-02T02:20:00Z",
+                    "uploaded": "2014-01-02T02:20:00Z",
+                    "watermark": {
+                        "created": "2014-01-02T02:20:00Z",
+                        "downloadedFrom": "https://company.com/logo.png",
+                        "height": 0,
+                        "name": "Marketing Videos",
+                        "opacity": 0.75,
+                        "padding": 0.1,
+                        "position": "center",
+                        "scale": 0.1,
+                        "size": 29472,
+                        "uid": "ea95132c15732412d22c1476fa83f27a",
+                        "width": 0,
+                    },
+                }
+            ],
+            "range": 1000,
+            "total": 35586,
+        },
+    )
+
+
+@pytest.fixture
+def mock_download_video(responses_mock, account_id, video_uid):
+    responses_mock.add(
+        responses.POST,
+        f"https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/{video_uid}/downloads",
+        json={"errors": [], "messages": [], "success": True, "result": {}},
+    )
+
+
+@pytest.fixture
+def mock_clip_video(responses_mock, account_id, clipped_video_uid, video_uid):
+    responses_mock.add(
+        responses.POST,
+        f"https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/clip",
+        json={
+            "errors": [],
+            "messages": [],
+            "success": True,
+            "result": {
+                "uid": clipped_video_uid,
+                "allowedOrigins": ["example.com"],
+                "clippedFromVideoUID": video_uid,
+                "created": "2014-01-02T02:20:00Z",
+                "creator": "creator-id_abcde12345",
+                "endTimeSeconds": 0,
+                "maxDurationSeconds": 1,
+                "meta": {"name": "video12345.mp4"},
+                "modified": "2014-01-02T02:20:00Z",
+                "playback": {
+                    "dash": "https://customer-m033z5x00ks6nunl.cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/manifest/video.mpd",
+                    "hls": "https://customer-m033z5x00ks6nunl.cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/manifest/video.m3u8",
                 },
-            }
-        ),
+                "preview": "https://customer-m033z5x00ks6nunl.cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/watch",
+                "requireSignedURLs": True,
+                "startTimeSeconds": 0,
+                "status": "inprogress",
+                "thumbnailTimestampPct": 0.529241,
+                "watermark": {"uid": "ea95132c15732412d22c1476fa83f27a"},
+            },
+        },
     )

--- a/baseapp_cloudflare_stream_field/tests/test_refresh_from_cloudfare.py
+++ b/baseapp_cloudflare_stream_field/tests/test_refresh_from_cloudfare.py
@@ -75,7 +75,11 @@ def test_refresh_from_cloudflare_not_ready(
 @patch("baseapp_cloudflare_stream_field.tasks.stream_client.get_video_data")
 @patch("django.contrib.contenttypes.models.ContentType.objects.get")
 def test_refresh_from_cloudflare_ready_with_error(
-    mock_get_content_type, mock_get_video_data, setup_video_not_ready, video_uid
+    mock_get_content_type,
+    mock_get_video_data,
+    setup_video_not_ready,
+    video_uid,
+    mock_delete_video_data,
 ):
     content_type, obj = setup_video_not_ready
 

--- a/baseapp_pdf/tests/integration/test_utils.py
+++ b/baseapp_pdf/tests/integration/test_utils.py
@@ -14,7 +14,7 @@ from baseapp_pdf.utils import (
 pytestmark = pytest.mark.django_db
 
 
-@pytest.mark.usefixtures("use_httpretty")
+@pytest.mark.usefixtures("responses_mock")
 class TestUtils:
     def test_utils_ensure_google_chrome_installed(self):
         ensure_google_chrome_installed()

--- a/baseapp_profiles/tests/test_graphql_mutations_update.py
+++ b/baseapp_profiles/tests/test_graphql_mutations_update.py
@@ -121,7 +121,6 @@ def test_owner_can_update_profile_url_path_already_in_use(django_user_client, gr
         variables={"input": {"id": profile.relay_id, "urlPath": url_path}},
     )
     content = response.json()
-    print(content)
     assert (
         content["data"]["profileUpdate"]["errors"][0]["messages"][0]
         == "Username already in use, suggested username: /existingpath1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,6 +79,7 @@ socialauth =
     hashids == 1.3.1
     rest-social-auth >= 8.1.0
     social-auth-core == 4.5.4
+    social-auth-app-django == 5.4.3
 pdf =
     pypdf == 5.6.0
 

--- a/testproject/requirements.txt
+++ b/testproject/requirements.txt
@@ -10,8 +10,8 @@ pytest-django==4.5.2
 pytest-asyncio==0.21.1
 pytest-celery==1.2.0
 
-httpretty==1.1.4
-urllib3==2.2.3
+responses==0.25.3
+urllib3==2.5.0
 # test factories
 factory-boy==3.2.1
 


### PR DESCRIPTION
Acceptance Criteria 
Current context

This library is no longer maintained, and it now has a critical vulnerability flagged by Safety.

We use httpretty for mocking HTTP requests in a few tests in baseapp-backend.

We also list httpretty in baseapp-backend-template, but we don’t actually use it there.

Expected output

Replace httpretty with a more modern library (e.g., `responses`).

Ensure all existing BA tests that use httpretty work correctly with the new package. 

Approvd 
https://app.approvd.io/silverlogic/BA/stories/42236 