### PR TITLE
fix: setup install_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     channels >= 4.0
     django-filter >= 23.3
     celery >= 5.2
-    django-pgtrigger >= 4.9, <= 4.12.2
+    django-pgtrigger == 4.14
     swapper >= 1.3
     django-model-utils >= 4.3
     djangorestframework >= 3.14
@@ -33,7 +33,7 @@ install_requires =
     djmail >= 2.0
     django-constance >= 4.3.2
     django_jinja >= 2.11
-    django-pghistory == 3.4.4
+    django-pghistory == 3.5.5
     django-ipware >= 7.0.1
     python-ipware >= 3.0.0
     requests >= 2.32.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned dependencies to exact versions for consistent installs:
    - django-pgtrigger: 4.14
    - django-pghistory: 3.5.5
  * Improves build determinism and reduces variability across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->