### PR TITLE
BA-2765-password-expiration

### DIFF
--- a/baseapp_auth/README.md
+++ b/baseapp_auth/README.md
@@ -107,7 +107,7 @@ CONSTANCE_CONFIG = OrderedDict(
         (
             "USER_PASSWORD_EXPIRATION_INTERVAL",
             (
-                365 * 2,
+                0,
                 "The time interval (in days) after which a user will need to reset their password.",
             ),
         ),

--- a/baseapp_auth/admin.py
+++ b/baseapp_auth/admin.py
@@ -72,6 +72,10 @@ class AbstractUserAdmin(UserAdmin):
     filter_horizontal = ()
     actions = ["force_expire_password"]
 
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.add_is_password_expired()
+
     def force_expire_password(self, request, queryset):
         if not request.user.mfa_methods.filter(is_active=True).exists():
             self.message_user(
@@ -91,7 +95,7 @@ class AbstractUserAdmin(UserAdmin):
     force_expire_password.short_description = "Expire password"
 
     def is_password_expired(self, obj):
-        return obj.is_password_expired
+        return obj.password_expired
 
     def save_model(self, request, obj, form, change):
         if change and hasattr(obj, "tracker") and obj.tracker.has_changed("is_superuser"):

--- a/baseapp_auth/managers.py
+++ b/baseapp_auth/managers.py
@@ -27,9 +27,6 @@ class UserManager(BaseUserManager):
         extra_fields["is_superuser"] = True
         return self._create_user(email, password, **extra_fields)
 
-    def get_queryset(self, *args, **kwargs) -> UserQuerySet:
-        return super().get_queryset(*args, **kwargs)
-
     def get_by_natural_key(self, email):
         # to be used by deserialization by natural keys (https://docs.djangoproject.com/en/4.2/topics/serialization/#deserialization-of-natural-keys)
         return self.get(email=email)

--- a/baseapp_auth/managers.py
+++ b/baseapp_auth/managers.py
@@ -28,7 +28,7 @@ class UserManager(BaseUserManager):
         return self._create_user(email, password, **extra_fields)
 
     def get_queryset(self, *args, **kwargs) -> UserQuerySet:
-        return super().get_queryset(*args, **kwargs).add_is_password_expired()
+        return super().get_queryset(*args, **kwargs)
 
     def get_by_natural_key(self, email):
         # to be used by deserialization by natural keys (https://docs.djangoproject.com/en/4.2/topics/serialization/#deserialization-of-natural-keys)

--- a/baseapp_auth/models.py
+++ b/baseapp_auth/models.py
@@ -120,7 +120,7 @@ class AbstractUser(PermissionsMixin, AbstractBaseUser, use_relay_model(), use_pr
         if "is_password_expired" in self.__dict__:
             return bool(self.__dict__["is_password_expired"])
 
-        expiration_interval = int(getattr(config, "USER_PASSWORD_EXPIRATION_INTERVAL", 0) or 0)
+        expiration_interval = int(getattr(config, "USER_PASSWORD_EXPIRATION_INTERVAL", 0))
         if expiration_interval <= 0:
             return False
 

--- a/baseapp_auth/rest_framework/login/serializers.py
+++ b/baseapp_auth/rest_framework/login/serializers.py
@@ -1,3 +1,4 @@
+from constance import config
 from django.contrib.auth import authenticate, get_user_model
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, serializers
@@ -10,7 +11,9 @@ User = get_user_model()
 
 class LoginPasswordExpirationMixin:
     def check_password_expiration(self, user):
-        if user.is_password_expired:
+        if config.USER_PASSWORD_EXPIRATION_INTERVAL == 0:
+            return
+        if user.password_expired:
             raise UserPasswordExpiredException(user=user)
 
 

--- a/baseapp_auth/rest_framework/login/views.py
+++ b/baseapp_auth/rest_framework/login/views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth import get_user_model
 from rest_framework import response, viewsets
 from rest_framework.permissions import AllowAny
 from trench.views.authtoken import MFAAuthTokenViewSetMixin
@@ -7,9 +8,14 @@ from baseapp_auth.rest_framework.mfa.mixins import MFAJWTLoginViewSetMixin
 from .helpers import redirect_if_user_has_expired_password
 from .serializers import LoginSerializer
 
+User = get_user_model()
 
-class AuthTokenViewSet(viewsets.GenericViewSet):
+
+class BaseAuthViewSet(viewsets.GenericViewSet):
     serializer_class = LoginSerializer
+
+
+class AuthTokenViewSet(BaseAuthViewSet):
 
     @redirect_if_user_has_expired_password
     def create(self, request, *args, **kwargs):
@@ -19,8 +25,7 @@ class AuthTokenViewSet(viewsets.GenericViewSet):
         return response.Response({"token": token.key})
 
 
-class MfaAuthTokenViewSet(viewsets.GenericViewSet, MFAAuthTokenViewSetMixin):
-    serializer_class = LoginSerializer
+class MfaAuthTokenViewSet(BaseAuthViewSet, MFAAuthTokenViewSetMixin):
     permission_classes = (AllowAny,)
 
     @redirect_if_user_has_expired_password
@@ -30,8 +35,7 @@ class MfaAuthTokenViewSet(viewsets.GenericViewSet, MFAAuthTokenViewSetMixin):
         return self.first_step_response(serializer.user)
 
 
-class MfaJwtViewSet(viewsets.GenericViewSet, MFAJWTLoginViewSetMixin):
-    serializer_class = LoginSerializer
+class MfaJwtViewSet(BaseAuthViewSet, MFAJWTLoginViewSetMixin):
     permission_classes = (AllowAny,)
 
     @redirect_if_user_has_expired_password

--- a/baseapp_auth/rest_framework/login/views.py
+++ b/baseapp_auth/rest_framework/login/views.py
@@ -1,4 +1,3 @@
-from django.contrib.auth import get_user_model
 from rest_framework import response, viewsets
 from rest_framework.permissions import AllowAny
 from trench.views.authtoken import MFAAuthTokenViewSetMixin
@@ -7,8 +6,6 @@ from baseapp_auth.rest_framework.mfa.mixins import MFAJWTLoginViewSetMixin
 
 from .helpers import redirect_if_user_has_expired_password
 from .serializers import LoginSerializer
-
-User = get_user_model()
 
 
 class BaseAuthViewSet(viewsets.GenericViewSet):

--- a/baseapp_auth/tasks.py
+++ b/baseapp_auth/tasks.py
@@ -9,6 +9,10 @@ User = get_user_model()
 
 @shared_task
 def notify_users_is_password_expired():
-    users = User.objects.all().filter(password_expiry_date__date=timezone.now())
+    users = (
+        User.objects.all()
+        .add_is_password_expired()
+        .filter(password_expiry_date__date=timezone.now())
+    )
     for user in users:
         send_password_expired_email(user)

--- a/baseapp_auth/tests/integration/test_change_expired_password.py
+++ b/baseapp_auth/tests/integration/test_change_expired_password.py
@@ -56,12 +56,12 @@ class TestChangeExpiredPasswordCreate(TestChangeExpiredPasswordListMixin):
             token=token,
         )
 
-        User.objects.get(pk=user.pk).is_password_expired is True
+        User.objects.get(pk=user.pk).password_expired is True
         r = client.post(self.reverse(), data=data)
         h.responseOk(r)
         self.check_data_keys(r.data)
         assert r.data["detail"] == "success"
-        User.objects.get(pk=user.pk).is_password_expired is False
+        User.objects.get(pk=user.pk).password_expired is False
 
         old_password = user.password
         user.refresh_from_db()

--- a/baseapp_auth/tests/integration/test_change_expired_password.py
+++ b/baseapp_auth/tests/integration/test_change_expired_password.py
@@ -56,12 +56,12 @@ class TestChangeExpiredPasswordCreate(TestChangeExpiredPasswordListMixin):
             token=token,
         )
 
-        User.objects.get(pk=user.pk).password_expired is True
+        assert User.objects.get(pk=user.pk).password_expired is True
         r = client.post(self.reverse(), data=data)
         h.responseOk(r)
         self.check_data_keys(r.data)
         assert r.data["detail"] == "success"
-        User.objects.get(pk=user.pk).password_expired is False
+        assert User.objects.get(pk=user.pk).password_expired is False
 
         old_password = user.password
         user.refresh_from_db()

--- a/baseapp_auth/tests/integration/test_login.py
+++ b/baseapp_auth/tests/integration/test_login.py
@@ -105,7 +105,6 @@ class TestLoginAuthToken(TestLoginBase):
         self.check_can_login_with_expired_password_when_interval_is_zero(client, data)
 
 
-
 class TestJwtRefresh(ApiMixin):
     login_endpoint_path = "/v1/auth/jwt/refresh"
 

--- a/baseapp_auth/tests/integration/test_login.py
+++ b/baseapp_auth/tests/integration/test_login.py
@@ -69,6 +69,15 @@ class TestLoginBase(ApiMixin):
         h.responseOk(r)
         assert "change-expired-password" in r.data["redirect_url"]
 
+    @override_config(USER_PASSWORD_EXPIRATION_INTERVAL=0)
+    def check_can_login_with_expired_password_when_interval_is_zero(self, client, data):
+        user = UserFactory(email=data["email"], password=data["password"])
+        user.password_changed_date = timezone.now() - timezone.timedelta(days=1)
+        user.save()
+        r = self.send_login_request(client, data)
+        h.responseOk(r)
+        assert "redirect_url" not in r.data
+
 
 class TestLoginAuthToken(TestLoginBase):
     login_endpoint_path = "/v1/auth/authtoken/login"
@@ -91,6 +100,10 @@ class TestLoginAuthToken(TestLoginBase):
 
     def test_login_with_expired_password_redirects_to_change_expired_password(self, client, data):
         self.check_login_with_expired_password_redirects_to_change_expired_password(client, data)
+
+    def test_can_login_with_expired_password_when_interval_is_zero(self, client, data):
+        self.check_can_login_with_expired_password_when_interval_is_zero(client, data)
+
 
 
 class TestJwtRefresh(ApiMixin):
@@ -126,6 +139,9 @@ class TestLoginJwt(TestLoginBase):
 
     def test_login_with_expired_password_redirects_to_change_expired_password(self, client, data):
         self.check_login_with_expired_password_redirects_to_change_expired_password(client, data)
+
+    def test_can_login_with_expired_password_when_interval_is_zero(self, client, data):
+        self.check_can_login_with_expired_password_when_interval_is_zero(client, data)
 
     def test_jwt_token_contains_user_data(self, client, data):
         user = UserFactory(email=data["email"], password=data["password"])

--- a/baseapp_auth/tests/unit/test_users.py
+++ b/baseapp_auth/tests/unit/test_users.py
@@ -57,3 +57,18 @@ def test_user_only_notified_once_for_expired_password():
         tasks.notify_users_is_password_expired()
         assert mock.call_count == 0
         mock.reset_mock()
+
+
+@override_config(USER_PASSWORD_EXPIRATION_INTERVAL=0)
+def test_user_password_never_expires_when_interval_is_zero():
+    user = UserFactory()
+    user.password_changed_date = timezone.now() - timezone.timedelta(days=1)
+    user.save()
+
+    mock = MagicMock()
+    tasks.send_password_expired_email = mock
+
+    tasks.notify_users_is_password_expired()
+
+    assert mock.call_count == 0
+    assert user.password_expired is False


### PR DESCRIPTION
## Current Scenario

- Right now `password_expiration` is not really stored anywhere. It's always calculated in the flight based in the `password_changed_date` attr. this attr will be changed first time password get's a value and when it updates. This also means we don't have a ready to read field with this data.

```python
    def save(self, *args, **kwargs):
        with self.tracker:
            if self.tracker.has_changed("password"):
                self.password_changed_date = timezone.now()
            super().save(*args, **kwargs)
```

There's also this method which will change `password_changed_date` and send an email. This is currently not being used anywhere besides under the admin action to force password expiration:

```python
    def force_expire_password(self, request, queryset):
        if not request.user.mfa_methods.filter(is_active=True).exists():
            self.message_user(
                request,
                _("You must be a superuser with MFA enabled to perform this action."),
                level=messages.ERROR,
            )
            return
        queryset.update(
            # Add extra time so the email doesn't get sent multiple times
            password_changed_date=timezone.now()
            - timezone.timedelta(days=config.USER_PASSWORD_EXPIRATION_INTERVAL + 7)
        )
        for user in queryset:
            send_password_expired_email(user)
```

The password expiration validation works because we are adding it to the managers queryset. Which means that every object will get this annotation (which is something that we definitely don't want.

```python
class UserManager(BaseUserManager):
		def get_queryset():
				return super().get_queryset(*args, **kwargs).add_is_password_expired()
```

Then it will be validated by:

```python
    def check_password_expiration(self, user):
        if user.is_password_expired:
            raise UserPasswordExpiredException(user=user)
```

## Changes applied by this PR

This implementation removes this default annotation from the manager's queryset by using the annotation where it really needs and by adding a property for the model instance, where it can be accessed when needed. E.g. `LoginSerializer` invoking check_password_expiration. 

Although I think a better approach would be really handling an is_expired "cache field",  this is a more simple way to workaround this unnecessary annotations happening through the manager. Without needing bigger changes for now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Option to globally disable password expiration by setting the interval to 0.
  - Admin UI now surfaces password-expiration status for users.

- Bug Fixes
  - Consistent password-expiration handling across login, admin, background notifications, and tasks.

- Documentation
  - README updated to show default expiration interval is 0.

- Refactor
  - Login viewsets consolidated onto a common base for simpler configuration.

- Tests
  - Updated and added tests covering interval == 0 behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->