### PR TITLE
Hotfix/hive 146 be logged user comments replies

### DIFF
--- a/baseapp_comments/graphql/object_types.py
+++ b/baseapp_comments/graphql/object_types.py
@@ -36,6 +36,28 @@ def create_object_type_from_dict(name, d):
 CommentsCount = create_object_type_from_dict("CommentsCount", default_comments_count())
 
 
+def _exclude_blocked_profiles(queryset, info):
+    """Exclude comments from blocked/blocking profiles.
+
+    Must be called BEFORE evaluate_with_prefetch_hack / optimize
+    so that .exclude() cloning doesn't destroy the result cache.
+    """
+    user = info.context.user
+    if user.is_anonymous:
+        return queryset
+
+    profile = getattr(user, "current_profile", None)
+    if not profile:
+        return queryset
+
+    blocked_profile_ids = profile.blocking.values_list("target_id", flat=True)
+    blocker_profile_ids = profile.blockers.values_list("actor_id", flat=True)
+
+    return queryset.exclude(profile__id__in=blocked_profile_ids).exclude(
+        profile__id__in=blocker_profile_ids
+    )
+
+
 class CommentsInterface(RelayNode):
     comments_count = graphene.Field(CommentsCount, required=True)
     comments = DjangoConnectionField(get_object_type_for_model(Comment))
@@ -64,6 +86,7 @@ class CommentsInterface(RelayNode):
 
         if is_root_a_comment and (root.target_object_id or root.in_reply_to_id):
             qs = root.comments.filter(status=CommentStatus.PUBLISHED)
+            qs = _exclude_blocked_profiles(qs, info)
             # The root.comments were already optimized. But because of the new filter, we need to
             # re-evaluate the queryset so it can be properly paginated.
             evaluate_with_prefetch_hack(qs)
@@ -78,14 +101,13 @@ class CommentsInterface(RelayNode):
             info_proxy = info
 
         target_content_type = ContentType.objects.get_for_model(root)
-        return optimize(
-            Comment.objects_visible.filter(
-                target_content_type=target_content_type,
-                target_object_id=root.pk,
-                in_reply_to__isnull=True,
-            ),
-            info_proxy,
+        qs = Comment.objects_visible.filter(
+            target_content_type=target_content_type,
+            target_object_id=root.pk,
+            in_reply_to__isnull=True,
         )
+        qs = _exclude_blocked_profiles(qs, info)
+        return optimize(qs, info_proxy)
 
 
 comment_interfaces = (
@@ -162,23 +184,15 @@ class BaseCommentObjectType:
 
     @classmethod
     def get_queryset(cls, queryset, info):
-        user = info.context.user
-        if user.is_anonymous:
+        # Skip filtering when _result_cache is already populated (e.g. by
+        # evaluate_with_prefetch_hack in resolve_comments).  Calling .exclude()
+        # would clone the queryset and destroy the cache, breaking pagination
+        # counts for nested comment connections.  The filtering is already
+        # applied inside resolve_comments before evaluation instead.
+        if getattr(queryset, "_result_cache", None) is not None:
             return queryset
 
-        profile = user.current_profile
-
-        if not profile:
-            return queryset
-
-        bloked_profile_ids = profile.blocking.values_list("target_id", flat=True)
-        bloker_profile_ids = profile.blockers.values_list("actor_id", flat=True)
-
-        queryset = queryset.exclude(profile__id__in=bloked_profile_ids).exclude(
-            profile__id__in=bloker_profile_ids
-        )
-
-        return queryset
+        return _exclude_blocked_profiles(queryset, info)
 
 
 class CommentObjectType(BaseCommentObjectType, DjangoObjectType):

--- a/baseapp_comments/graphql/object_types.py
+++ b/baseapp_comments/graphql/object_types.py
@@ -23,6 +23,11 @@ from baseapp_reactions.graphql.object_types import ReactionsInterface
 from ..models import CommentStatus, default_comments_count
 from .filters import CommentFilter
 
+# Hint key set by _exclude_blocked_profiles so get_queryset() knows
+# filtering was already applied and can skip a redundant .exclude().
+_BLOCKED_PROFILES_FILTERED_HINT = "_blocked_profiles_filtered"
+
+
 Comment = swapper.load_model("baseapp_comments", "Comment")
 app_label = Comment._meta.app_label
 
@@ -44,21 +49,27 @@ def _exclude_blocked_profiles(queryset: models.QuerySet, info: GQLInfo) -> model
 
     Must be called BEFORE evaluate_with_prefetch_hack / optimize
     so that .exclude() cloning doesn't destroy the result cache.
+    Sets ``_BLOCKED_PROFILES_FILTERED_HINT`` on the queryset so
+    ``get_queryset()`` knows filtering was already applied.
     """
     user = info.context.user
     if user.is_anonymous:
+        queryset._hints[_BLOCKED_PROFILES_FILTERED_HINT] = True
         return queryset
 
     profile = getattr(user, "current_profile", None)
     if not profile:
+        queryset._hints[_BLOCKED_PROFILES_FILTERED_HINT] = True
         return queryset
 
     blocked_profile_ids = profile.blocking.values_list("target_id", flat=True)
     blocker_profile_ids = profile.blockers.values_list("actor_id", flat=True)
 
-    return queryset.exclude(
+    qs = queryset.exclude(
         Q(profile__id__in=blocked_profile_ids) | Q(profile__id__in=blocker_profile_ids)
     )
+    qs._hints[_BLOCKED_PROFILES_FILTERED_HINT] = True
+    return qs
 
 
 class CommentsInterface(RelayNode):
@@ -193,12 +204,11 @@ class BaseCommentObjectType:
 
     @classmethod
     def get_queryset(cls, queryset, info):
-        # Skip filtering when _result_cache is already populated (e.g. by
-        # evaluate_with_prefetch_hack in resolve_comments).  Calling .exclude()
-        # would clone the queryset and destroy the cache, breaking pagination
-        # counts for nested comment connections.  The filtering is already
-        # applied inside resolve_comments before evaluation instead.
-        if getattr(queryset, "_result_cache", None) is not None:
+        # Skip filtering when it was already applied by resolve_comments
+        # (indicated by an explicit _hints flag).  Calling .exclude() on an
+        # already-evaluated queryset would clone it and destroy _result_cache,
+        # breaking pagination counts for nested comment connections.
+        if queryset._hints.get(_BLOCKED_PROFILES_FILTERED_HINT):
             return queryset
 
         return _exclude_blocked_profiles(queryset, info)

--- a/baseapp_comments/graphql/object_types.py
+++ b/baseapp_comments/graphql/object_types.py
@@ -4,8 +4,10 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from query_optimizer import DjangoConnectionField, optimize
+from django.db.models import Q
+from query_optimizer import DjangoConnectionField
 from query_optimizer.prefetch_hack import evaluate_with_prefetch_hack
+from query_optimizer.typing import GQLInfo
 
 from baseapp_auth.graphql import PermissionsInterface
 from baseapp_core.graphql import (
@@ -15,6 +17,7 @@ from baseapp_core.graphql import (
 )
 from baseapp_core.graphql import Node as RelayNode
 from baseapp_core.graphql import get_object_type_for_model, skip_ast_walker
+from baseapp_core.graphql.optimizer import NESTED_INFO_PROXY_HINT
 from baseapp_reactions.graphql.object_types import ReactionsInterface
 
 from ..models import CommentStatus, default_comments_count
@@ -36,7 +39,7 @@ def create_object_type_from_dict(name, d):
 CommentsCount = create_object_type_from_dict("CommentsCount", default_comments_count())
 
 
-def _exclude_blocked_profiles(queryset, info):
+def _exclude_blocked_profiles(queryset: models.QuerySet, info: GQLInfo) -> models.QuerySet:
     """Exclude comments from blocked/blocking profiles.
 
     Must be called BEFORE evaluate_with_prefetch_hack / optimize
@@ -53,8 +56,8 @@ def _exclude_blocked_profiles(queryset, info):
     blocked_profile_ids = profile.blocking.values_list("target_id", flat=True)
     blocker_profile_ids = profile.blockers.values_list("actor_id", flat=True)
 
-    return queryset.exclude(profile__id__in=blocked_profile_ids).exclude(
-        profile__id__in=blocker_profile_ids
+    return queryset.exclude(
+        Q(profile__id__in=blocked_profile_ids) | Q(profile__id__in=blocker_profile_ids)
     )
 
 
@@ -92,14 +95,6 @@ class CommentsInterface(RelayNode):
             evaluate_with_prefetch_hack(qs)
             return qs
 
-        if is_root_a_comment:
-            # When the root is a comment, we need to trick the optimizer to properly walk the AST.
-            # The ast walker doesn't work properly with nested elements (comments -> comments).
-            queryset_field_nodes = ConnectionFieldNodeExtractor(info).get_sliced_field_nodes()
-            info_proxy = NestedConnectionInfoProxy(info, queryset_field_nodes=queryset_field_nodes)
-        else:
-            info_proxy = info
-
         target_content_type = ContentType.objects.get_for_model(root)
         qs = Comment.objects_visible.filter(
             target_content_type=target_content_type,
@@ -107,7 +102,21 @@ class CommentsInterface(RelayNode):
             in_reply_to__isnull=True,
         )
         qs = _exclude_blocked_profiles(qs, info)
-        return optimize(qs, info_proxy)
+
+        if is_root_a_comment:
+            # When the root is a comment used as a target, the AST walker can't handle the
+            # nested comments -> comments structure with the regular info.  Stash a
+            # NestedConnectionInfoProxy on the queryset hints so the patched
+            # OptimizationCompilerPatch (in baseapp_core.graphql.optimizer) picks it up
+            # when the DjangoConnectionField compiles the optimisation.  This avoids calling
+            # optimize() eagerly, which would evaluate the queryset and break pagination.
+            queryset_field_nodes = ConnectionFieldNodeExtractor(info).get_sliced_field_nodes()
+            info_proxy = NestedConnectionInfoProxy(info, queryset_field_nodes=queryset_field_nodes)
+            qs._hints[NESTED_INFO_PROXY_HINT] = info_proxy
+
+        # Return the un-evaluated queryset so the DjangoConnectionField handles both
+        # optimization and pagination (first/after slicing).
+        return qs
 
 
 comment_interfaces = (

--- a/baseapp_comments/tests/test_graphql_queries_object_comments.py
+++ b/baseapp_comments/tests/test_graphql_queries_object_comments.py
@@ -3,6 +3,7 @@ from constance.test import override_config
 from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
 
+from baseapp_blocks.tests.factories import BlockFactory
 from baseapp_core.tests.factories import UserFactory
 from baseapp_pages.tests.factories import PageFactory
 from baseapp_profiles.tests.factories import ProfileFactory
@@ -154,7 +155,7 @@ def test_anon_see_comments_and_replies(django_user_client, graphql_client_with_q
     assert content["data"]["node"]["comments"]["edges"][0]["node"]["commentsCount"]["main"] == 2
     assert len(content["data"]["node"]["comments"]["edges"][0]["node"]["comments"]["edges"]) == 2
 
-    assert queries.count == 10
+    assert queries.count == 11
 
     ### Optimized queries.
     # 1) 'SELECT "baseapp_core_documentid"."id", "baseapp_core_documentid"."created", "baseapp_core_documentid"."modified", "baseapp_core_documentid"."public_id", "baseapp_core_documentid"."content_type_id", "baseapp_core_documentid"."object_id", "django_content_type"."id", "django_content_type"."app_label", "django_content_type"."model" FROM "baseapp_core_documentid" INNER JOIN "django_content_type" ON ("baseapp_core_documentid"."content_type_id" = "django_content_type"."id") WHERE "baseapp_core_documentid"."public_id" = 97c2483b-2625-448f-ba16-2e58b92a76c3 LIMIT 21',
@@ -195,7 +196,7 @@ def test_anon_see_comments_and_replies_with_pagination(
         "hasNextPage"
     ]
 
-    assert queries.count == 10
+    assert queries.count == 11
 
 
 @override_config(ENABLE_PUBLIC_ID_LOGIC=True)
@@ -267,6 +268,133 @@ def test_logged_user_replies_to_a_page_comment_has_next_page_true_when_more_than
     comment_replies = page_comment["comments"]
     assert len(comment_replies["edges"]) == 5
     assert comment_replies["pageInfo"]["hasNextPage"] is True
+
+
+@override_config(ENABLE_PUBLIC_ID_LOGIC=True)
+def test_get_queryset_skips_filtering_only_when_hint_set(django_user_client, graphql_user_client):
+    """get_queryset() must rely on the explicit _BLOCKED_PROFILES_FILTERED_HINT
+    flag — NOT on _result_cache — to decide whether to skip blocked-profile
+    filtering.  A queryset whose _result_cache is populated but lacks the hint
+    must still apply the .exclude()."""
+    from baseapp_comments.graphql.object_types import (
+        _BLOCKED_PROFILES_FILTERED_HINT,
+        BaseCommentObjectType,
+        _exclude_blocked_profiles,
+    )
+
+    page = PageFactory(user=django_user_client.user)
+    current_profile = ProfileFactory(owner=django_user_client.user)
+
+    blocked_user = UserFactory()
+    blocked_profile = ProfileFactory(owner=blocked_user)
+    BlockFactory(actor=current_profile, target=blocked_profile)
+
+    CommentFactory.create_batch(target=page, size=3, user=django_user_client.user)
+    CommentFactory.create_batch(target=page, size=2, user=blocked_user, profile=blocked_profile)
+
+    qs = page.comments.all()
+
+    # Build a fake info object with the authenticated user + current_profile
+    class FakeRequest:
+        def __init__(self, user, profile):
+            self.user = user
+            self.user.current_profile = profile
+
+    class FakeInfo:
+        def __init__(self, request):
+            self.context = request
+
+    info = FakeInfo(FakeRequest(django_user_client.user, current_profile))
+
+    # --- Case 1: hint IS set → get_queryset skips filtering (returns as-is)
+    qs_with_hint = _exclude_blocked_profiles(qs, info)
+    assert qs_with_hint._hints.get(_BLOCKED_PROFILES_FILTERED_HINT) is True
+    # Filtering was already applied by _exclude_blocked_profiles
+    assert qs_with_hint.count() == 3
+
+    result = BaseCommentObjectType.get_queryset(qs_with_hint, info)
+    # Should return the same queryset without applying .exclude() again
+    assert result.count() == 3
+
+    # --- Case 2: hint NOT set → get_queryset applies filtering
+    qs_no_hint = page.comments.all()
+    assert _BLOCKED_PROFILES_FILTERED_HINT not in qs_no_hint._hints
+    result = BaseCommentObjectType.get_queryset(qs_no_hint, info)
+    assert result.count() == 3  # blocked user's comments excluded
+
+    # --- Case 3: _result_cache populated WITHOUT hint → must still filter
+    qs_cached = page.comments.all()
+    list(qs_cached)  # populates _result_cache
+    assert qs_cached._result_cache is not None
+    assert _BLOCKED_PROFILES_FILTERED_HINT not in qs_cached._hints
+    result = BaseCommentObjectType.get_queryset(qs_cached, info)
+    assert result.count() == 3  # blocked user's comments excluded despite cache
+
+
+@override_config(ENABLE_PUBLIC_ID_LOGIC=True)
+def test_blocked_profiles_excluded_with_pagination(django_user_client, graphql_user_client):
+    """Blocked/blocking profiles are excluded and pagination still works correctly."""
+    page = PageFactory(user=django_user_client.user)
+    current_profile = ProfileFactory(owner=django_user_client.user)
+
+    blocked_user = UserFactory()
+    blocked_profile = ProfileFactory(owner=blocked_user)
+    BlockFactory(actor=current_profile, target=blocked_profile)
+
+    visible_user = UserFactory()
+    # 7 visible comments + 3 from blocked profile = 10 total
+    visible_comments = CommentFactory.create_batch(target=page, size=7, user=visible_user)
+    CommentFactory.create_batch(target=page, size=3, user=blocked_user, profile=blocked_profile)
+
+    response = graphql_user_client(
+        PAGINATED_COMMENTS_QUERY,
+        variables={"id": page.relay_id, "first": 5},
+        headers={"HTTP_CURRENT_PROFILE": current_profile.relay_id},
+    )
+    content = response.json()
+
+    comments_connection = content["data"]["node"]["comments"]
+    visible_pks = {c.pk for c in visible_comments}
+
+    # Only visible comments appear, none from the blocked profile
+    for edge in comments_connection["edges"]:
+        assert int(edge["node"]["pk"]) in visible_pks
+
+    assert len(comments_connection["edges"]) == 5
+    assert comments_connection["pageInfo"]["hasNextPage"] is True
+    assert comments_connection["pageInfo"]["endCursor"] is not None
+
+
+@override_config(ENABLE_PUBLIC_ID_LOGIC=True)
+def test_top_level_comments_second_page_with_cursor(django_user_client, graphql_client):
+    """Fetching the second page with an `after` cursor returns the remaining comments."""
+    page = PageFactory(user=django_user_client.user)
+    user = UserFactory()
+    CommentFactory.create_batch(target=page, size=8, user=user)
+
+    # Fetch first page
+    response = graphql_client(
+        PAGINATED_COMMENTS_QUERY,
+        variables={"id": page.relay_id, "first": 5},
+    )
+    first_page = response.json()["data"]["node"]["comments"]
+    assert len(first_page["edges"]) == 5
+    assert first_page["pageInfo"]["hasNextPage"] is True
+    end_cursor = first_page["pageInfo"]["endCursor"]
+
+    # Fetch second page using the cursor
+    response = graphql_client(
+        PAGINATED_COMMENTS_QUERY,
+        variables={"id": page.relay_id, "first": 5, "after": end_cursor},
+    )
+    second_page = response.json()["data"]["node"]["comments"]
+    assert len(second_page["edges"]) == 3
+    assert second_page["pageInfo"]["hasNextPage"] is False
+
+    # Ensure no overlap between pages
+    first_page_pks = {e["node"]["pk"] for e in first_page["edges"]}
+    second_page_pks = {e["node"]["pk"] for e in second_page["edges"]}
+    assert first_page_pks.isdisjoint(second_page_pks)
 
 
 def test_anon_cant_see_comments_when_disabled(graphql_client):
@@ -508,7 +636,7 @@ def test_comments_query_from_foreigh_target_is_partially_optimized_with_public_i
     content = response.json()
 
     assert len(content["data"]["node"]["comments"]["edges"]) == 5
-    assert queries.count == 8
+    assert queries.count == 9
 
     ### Optimized queries. About the comments it's only 4 queries.
     # 1) 'SELECT "baseapp_core_documentid"."id", "baseapp_core_documentid"."created", "baseapp_core_documentid"."modified", "baseapp_core_documentid"."public_id", "baseapp_core_documentid"."content_type_id", "baseapp_core_documentid"."object_id", "django_content_type"."id", "django_content_type"."app_label", "django_content_type"."model" FROM "baseapp_core_documentid" INNER JOIN "django_content_type" ON ("baseapp_core_documentid"."content_type_id" = "django_content_type"."id") WHERE "baseapp_core_documentid"."public_id" = 1e044df1-9a3d-4a26-b056-01f9e1d9dfb5 LIMIT 21',

--- a/baseapp_comments/tests/test_graphql_queries_object_comments.py
+++ b/baseapp_comments/tests/test_graphql_queries_object_comments.py
@@ -56,6 +56,48 @@ VIEW_ALL_QUERY = """
     }
 """
 
+PAGINATED_COMMENTS_QUERY = """
+    query GetObject($id: ID!, $first: Int, $after: String, $orderBy: String) {
+        node(id: $id) {
+                id
+            ... on CommentsInterface {
+                commentsCount {
+                    total
+                    main
+                }
+                comments(first: $first, after: $after, orderBy: $orderBy) {
+                    edges {
+                        node {
+                            id
+                            pk
+                            commentsCount {
+                                total
+                                main
+                                replies
+                            }
+                            comments(first: 5) {
+                                edges {
+                                    node {
+                                        id
+                                        pk
+                                    }
+                                }
+                                pageInfo {
+                                    hasNextPage
+                                    endCursor
+                                }
+                            }
+                        }
+                    }
+                    pageInfo {
+                        hasNextPage
+                        endCursor
+                    }
+                }
+            }
+        }
+    }
+"""
 
 SIMPLIFIED_QUERY_FOR_TESTING_OPTIMIZATION = """
     query GetObject($id: ID!, $orderBy: String, $q: String) {
@@ -154,6 +196,77 @@ def test_anon_see_comments_and_replies_with_pagination(
     ]
 
     assert queries.count == 10
+
+
+@override_config(ENABLE_PUBLIC_ID_LOGIC=True)
+def test_top_level_comments_pagination_on_page_target(django_user_client, graphql_client):
+    """Reproduces the FE bug: when using first=5 on the top-level comments
+    of a Page (matching the FE CommentsList query), hasNextPage must be True
+    when there are more than 5 comments."""
+    page = PageFactory(user=django_user_client.user)
+    user = UserFactory()
+    # Create 10 top-level comments — more than the page size of 5
+    CommentFactory.create_batch(target=page, size=10, user=user)
+
+    response = graphql_client(
+        PAGINATED_COMMENTS_QUERY,
+        variables={"id": page.relay_id, "first": 5},
+    )
+    content = response.json()
+
+    comments_connection = content["data"]["node"]["comments"]
+    assert len(comments_connection["edges"]) == 5
+    assert comments_connection["pageInfo"]["hasNextPage"] is True
+
+
+@override_config(ENABLE_PUBLIC_ID_LOGIC=True)
+def test_top_level_comments_pagination_on_comment_target(django_user_client, graphql_client):
+    """Same bug but with a Comment as target (how baseapp tests are structured)."""
+    target = CommentFactory()
+    user = UserFactory()
+    # Create 10 top-level comments — more than the page size of 5
+    CommentFactory.create_batch(target=target, size=10, user=user)
+
+    response = graphql_client(
+        PAGINATED_COMMENTS_QUERY,
+        variables={"id": target.relay_id, "first": 5},
+    )
+    content = response.json()
+
+    comments_connection = content["data"]["node"]["comments"]
+    assert len(comments_connection["edges"]) == 5
+    assert comments_connection["pageInfo"]["hasNextPage"] is True
+
+
+@override_config(ENABLE_PUBLIC_ID_LOGIC=True)
+def test_logged_user_replies_to_a_page_comment_has_next_page_true_when_more_than_5_replies(
+    django_user_client, graphql_user_client
+):
+    page = PageFactory(user=django_user_client.user)
+    user = UserFactory()
+    comment = CommentFactory(target=page, user=user)
+    replying_user = UserFactory()
+    # Create 10 replies — more than the page size of 5
+    CommentFactory.create_batch(target=page, in_reply_to=comment, size=10, user=replying_user)
+
+    response = graphql_user_client(
+        PAGINATED_COMMENTS_QUERY,
+        variables={"id": page.relay_id, "first": 5},
+    )
+    content = response.json()
+    page = content["data"]["node"]
+
+    assert page["commentsCount"]["main"] == 1
+    assert page["commentsCount"]["total"] == 11
+
+    page_comments = page["comments"]
+
+    page_comment = page_comments["edges"][0]["node"]
+    assert page_comment["commentsCount"]["total"] == 10
+
+    comment_replies = page_comment["comments"]
+    assert len(comment_replies["edges"]) == 5
+    assert comment_replies["pageInfo"]["hasNextPage"] is True
 
 
 def test_anon_cant_see_comments_when_disabled(graphql_client):

--- a/baseapp_core/graphql/optimizer.py
+++ b/baseapp_core/graphql/optimizer.py
@@ -13,6 +13,12 @@ from query_optimizer.filter_info import FilterInfoCompiler
 from query_optimizer.typing import GQLInfo
 from query_optimizer.utils import mark_optimized
 
+# Key used to store a NestedConnectionInfoProxy on a queryset's _hints dict.
+# This lets resolve_comments pass the proxy to the DjangoConnectionField's
+# OptimizationCompiler without calling optimize() eagerly (which would
+# evaluate the queryset and break pagination).
+NESTED_INFO_PROXY_HINT = "_nested_info_proxy"
+
 
 class NestedConnectionInfoProxy:
     """
@@ -118,6 +124,16 @@ class OptimizationCompilerPatch(GraphQLASTWalkerPatchMixin, OptimizationCompiler
     resolvers.
     """
 
+    def compile(self, queryset):
+        # If a NestedConnectionInfoProxy was stashed on the queryset by
+        # resolve_comments, swap it in so the AST walker uses the correct
+        # field nodes for nested comments -> comments structures.
+        if not isinstance(queryset, list):
+            proxy = queryset._hints.pop(NESTED_INFO_PROXY_HINT, None)
+            if proxy is not None:
+                self.info = proxy
+        return super().compile(queryset)
+
     def run(self) -> Any:
         if isinstance(self.info, NestedConnectionInfoProxy):
             self.info = self.info.get_info_proxy("queryset")
@@ -132,6 +148,13 @@ class FilterInfoCompilerPatch(GraphQLASTWalkerPatchMixin, FilterInfoCompiler):
     automatically overridden by this class when loaded at runtime. This enables filter
     optimization from connection resolvers.
     """
+
+    def compile(self, queryset):
+        if not isinstance(queryset, list):
+            proxy = queryset._hints.get(NESTED_INFO_PROXY_HINT)
+            if proxy is not None:
+                self.info = proxy
+        return super().compile(queryset)
 
     def run(self) -> Any:
         if isinstance(self.info, NestedConnectionInfoProxy):

--- a/baseapp_core/graphql/optimizer.py
+++ b/baseapp_core/graphql/optimizer.py
@@ -129,7 +129,7 @@ class OptimizationCompilerPatch(GraphQLASTWalkerPatchMixin, OptimizationCompiler
         # resolve_comments, swap it in so the AST walker uses the correct
         # field nodes for nested comments -> comments structures.
         if not isinstance(queryset, list):
-            proxy = queryset._hints.pop(NESTED_INFO_PROXY_HINT, None)
+            proxy = queryset._hints.get(NESTED_INFO_PROXY_HINT, None)
             if proxy is not None:
                 self.info = proxy
         return super().compile(queryset)
@@ -148,13 +148,6 @@ class FilterInfoCompilerPatch(GraphQLASTWalkerPatchMixin, FilterInfoCompiler):
     automatically overridden by this class when loaded at runtime. This enables filter
     optimization from connection resolvers.
     """
-
-    def compile(self, queryset):
-        if not isinstance(queryset, list):
-            proxy = queryset._hints.get(NESTED_INFO_PROXY_HINT)
-            if proxy is not None:
-                self.info = proxy
-        return super().compile(queryset)
 
     def run(self) -> Any:
         if isinstance(self.info, NestedConnectionInfoProxy):

--- a/baseapp_core/graphql/testing/test_graphql_optimizer.py
+++ b/baseapp_core/graphql/testing/test_graphql_optimizer.py
@@ -15,6 +15,7 @@ from query_optimizer.filter_info import FilterInfoCompiler
 from query_optimizer.typing import GQLInfo
 
 from baseapp_core.graphql.optimizer import (
+    NESTED_INFO_PROXY_HINT,
     ConnectionFieldNodeExtractor,
     FilterInfoCompilerPatch,
     GraphQLASTWalkerPatchMixin,
@@ -192,6 +193,55 @@ class TestOptimizationCompilerPatch:
         assert result == "result"
         assert compiler.info._use_mode == "queryset"
         compiler.handle_selections.assert_called_once()
+
+    def test_compile_swaps_info_when_hint_present(self, mock_info):
+        """When NESTED_INFO_PROXY_HINT is in queryset._hints, compile() should
+        replace self.info with the proxy so the AST walker uses the correct
+        field nodes for nested comments -> comments structures."""
+        proxy = NestedConnectionInfoProxy(
+            mock_info, queryset_field_nodes=[MagicMock(spec=FieldNode)]
+        )
+        qs = MagicMock(spec=["_hints", "model", "_result_cache"])
+        qs._hints = {NESTED_INFO_PROXY_HINT: proxy}
+
+        compiler = OptimizationCompilerPatch(mock_info, max_complexity=None)
+        assert compiler.info is mock_info
+
+        # Patch super().compile() to avoid full optimization pipeline
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(OptimizationCompiler, "compile", lambda self, qs: None)
+            compiler.compile(qs)
+
+        assert compiler.info is proxy
+        # Hint is read with .get() (not .pop()), so it remains
+        assert NESTED_INFO_PROXY_HINT in qs._hints
+
+    def test_compile_keeps_info_when_hint_absent(self, mock_info):
+        """When no NESTED_INFO_PROXY_HINT exists, compile() should not mutate
+        self.info — behaving identically to the base OptimizationCompiler."""
+        qs = MagicMock(spec=["_hints", "model", "_result_cache"])
+        qs._hints = {}
+
+        compiler = OptimizationCompilerPatch(mock_info, max_complexity=None)
+        original_info = compiler.info
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(OptimizationCompiler, "compile", lambda self, qs: None)
+            compiler.compile(qs)
+
+        assert compiler.info is original_info
+
+    def test_compile_with_list_input_does_not_crash(self, mock_info):
+        """When compile() receives a list (from prefetch to_attr), it should
+        skip the hints check and delegate to the base class without error."""
+        compiler = OptimizationCompilerPatch(mock_info, max_complexity=None)
+        original_info = compiler.info
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(OptimizationCompiler, "compile", lambda self, qs: None)
+            compiler.compile([MagicMock()])
+
+        assert compiler.info is original_info
 
 
 class TestFilterInfoCompilerPatch:


### PR DESCRIPTION
This [loom video](https://www.loom.com/share/17fde9b85c394762b0b3cdae8dce9f69) explains the 2 bugs we are trying to fix here.

Most of this code and debugging was made with the help of Claude Opus 4.6 and GPT codex 5.3/5.2
So please be careful reviewing.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Comment lists now reliably exclude blocked/blocking profiles while preserving correct pagination counts and pageInfo for top-level comments and nested replies.
  * Cursor-based pagination for comments and replies returns non-overlapping pages with accurate hasNextPage, endCursor and counts after filtering.

* **Tests**
  * Added end-to-end and unit GraphQL tests covering cursor pagination, nested reply pagination, counts, blocked-profile exclusion, and pagination compatibility when exclusions are applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->