### PR TITLE
Notifications count does not update when reactions are done

### DIFF
--- a/baseapp_comments/tests/conftest.py
+++ b/baseapp_comments/tests/conftest.py
@@ -1,2 +1,10 @@
+from celery import current_app
+
 from baseapp_core.graphql.testing.fixtures import *  # noqa
 from baseapp_core.tests.fixtures import *  # noqa
+
+# Apply Django's CELERY_* settings (including CELERY_TASK_ALWAYS_EAGER=True) to the
+# Celery default_app so .delay() runs synchronously in tests. Must run at module level
+# — a fixture would only configure the app instance on the main thread's task stack,
+# which worker threads (spawned by database_sync_to_async in async tests) can't see.
+current_app.config_from_object("django.conf:settings", namespace="CELERY")

--- a/baseapp_comments/tests/test_graphql_notification_subscriptions.py
+++ b/baseapp_comments/tests/test_graphql_notification_subscriptions.py
@@ -1,0 +1,162 @@
+import textwrap
+
+import pytest
+from channels.db import database_sync_to_async
+from django.test import override_settings
+
+from baseapp_core.graphql.testing.fixtures import graphql_query
+from baseapp_core.tests.factories import UserFactory
+from baseapp_core.tests.fixtures import DjangoClient
+
+from .factories import CommentFactory
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+NOTIFICATION_SUBSCRIPTION_QUERY = textwrap.dedent("""
+    subscription op_name {
+      onNotificationChange {
+        createdNotification {
+          node {
+            id
+            verb
+            recipient {
+              id
+              notificationsUnreadCount
+            }
+          }
+        }
+      }
+    }
+    """)
+
+COMMENT_CREATE_GRAPHQL = """
+    mutation CommentCreateMutation($input: CommentCreateInput!) {
+        commentCreate(input: $input) {
+            comment {
+                node {
+                    id
+                    body
+                }
+            }
+            errors {
+                field
+                messages
+            }
+        }
+    }
+"""
+
+
+@pytest.mark.asyncio
+@override_settings(BASEAPP_COMMENTS_ENABLE_NOTIFICATIONS=True)
+async def test_comment_created_subscription_has_correct_unread_count(
+    django_user_client, graphql_ws_user_client
+):
+    # Setup: django_user_client.user (User A) owns a comment target
+    target = await database_sync_to_async(CommentFactory)(user=django_user_client.user)
+    target_relay_id = await database_sync_to_async(lambda: target.relay_id)()
+
+    # Subscribe as User A (the target owner who will receive the notification)
+    client = await graphql_ws_user_client(consumer_attrs={"strict_ordering": True})
+    try:
+        sub_id = await client.send(
+            msg_type="subscribe",
+            payload={
+                "query": NOTIFICATION_SUBSCRIPTION_QUERY,
+                "operationName": "op_name",
+            },
+        )
+        await client.assert_no_messages()
+
+        # Action: User B creates a comment on User A's target
+        commenter = await database_sync_to_async(UserFactory)()
+        commenter_client = DjangoClient()
+        await database_sync_to_async(commenter_client.force_login)(commenter)
+
+        response = await database_sync_to_async(graphql_query)(
+            COMMENT_CREATE_GRAPHQL,
+            variables={
+                "input": {
+                    "targetObjectId": target_relay_id,
+                    "body": "Nice comment!",
+                }
+            },
+            client=commenter_client,
+        )
+        content = response.json()
+        assert "errors" not in content
+
+        # Verify: subscription message has correct verb and unread count
+        resp = await client.receive(assert_id=sub_id, assert_type="next")
+        notification = resp["data"]["onNotificationChange"]["createdNotification"]["node"]
+        assert notification["verb"] == "COMMENTS.COMMENT_CREATED"
+        assert notification["recipient"]["notificationsUnreadCount"] == 1
+    finally:
+        await client.finalize()
+
+
+@pytest.mark.asyncio
+@override_settings(BASEAPP_COMMENTS_ENABLE_NOTIFICATIONS=True)
+async def test_comment_reply_subscription_has_correct_unread_count(
+    django_user_client, graphql_ws_user_client
+):
+    # Setup: User C owns a target, User A (django_user_client.user) writes a parent comment on it
+    target_owner = await database_sync_to_async(UserFactory)()
+    target = await database_sync_to_async(CommentFactory)(user=target_owner)
+    target_relay_id = await database_sync_to_async(lambda: target.relay_id)()
+
+    user_a_client = DjangoClient()
+    await database_sync_to_async(user_a_client.force_login)(django_user_client.user)
+
+    response = await database_sync_to_async(graphql_query)(
+        COMMENT_CREATE_GRAPHQL,
+        variables={
+            "input": {
+                "targetObjectId": target_relay_id,
+                "body": "Parent comment",
+            }
+        },
+        client=user_a_client,
+    )
+    content = response.json()
+    assert "errors" not in content
+    parent_comment_id = content["data"]["commentCreate"]["comment"]["node"]["id"]
+
+    # Subscribe as User A (the parent comment author)
+    client = await graphql_ws_user_client(consumer_attrs={"strict_ordering": True})
+    try:
+        sub_id = await client.send(
+            msg_type="subscribe",
+            payload={
+                "query": NOTIFICATION_SUBSCRIPTION_QUERY,
+                "operationName": "op_name",
+            },
+        )
+        await client.assert_no_messages()
+
+        # Action: User B replies to User A's comment
+        replier = await database_sync_to_async(UserFactory)()
+        replier_client = DjangoClient()
+        await database_sync_to_async(replier_client.force_login)(replier)
+
+        response = await database_sync_to_async(graphql_query)(
+            COMMENT_CREATE_GRAPHQL,
+            variables={
+                "input": {
+                    "targetObjectId": target_relay_id,
+                    "body": "Reply to your comment!",
+                    "inReplyToId": parent_comment_id,
+                }
+            },
+            client=replier_client,
+        )
+        content = response.json()
+        assert "errors" not in content
+
+        # Verify: subscription message has correct verb and unread count
+        resp = await client.receive(assert_id=sub_id, assert_type="next")
+        notification = resp["data"]["onNotificationChange"]["createdNotification"]["node"]
+        assert notification["verb"] == "COMMENTS.COMMENT_REPLY_CREATED"
+        assert notification["recipient"]["notificationsUnreadCount"] == 1
+    finally:
+        await client.finalize()

--- a/baseapp_notifications/base.py
+++ b/baseapp_notifications/base.py
@@ -17,14 +17,19 @@ class AbstractNotification(BaseAbstractNotification, RelayModel):
 
         from baseapp_notifications.graphql.subscriptions import OnNotificationChange
 
-        if created:
-            transaction.on_commit(
-                lambda: OnNotificationChange.send_created_notification(notification=self)
-            )
-        else:
-            transaction.on_commit(
-                lambda: OnNotificationChange.send_updated_notification(notification=self)
-            )
+        pk = self.pk
+        Notification = type(self)
+
+        def broadcast():
+            notification = Notification.objects.filter(pk=pk).first()
+            if notification is None:
+                return
+            if created:
+                OnNotificationChange.send_created_notification(notification=notification)
+            else:
+                OnNotificationChange.send_updated_notification(notification=notification)
+
+        transaction.on_commit(broadcast)
 
     def delete(self, *args, **kwargs):
         notification_relay_id = self.relay_id

--- a/baseapp_notifications/base.py
+++ b/baseapp_notifications/base.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.db import models
+from django.db import models, transaction
 from django.utils.translation import gettext_lazy as _
 from model_utils.models import TimeStampedModel
 from notifications.base.models import AbstractNotification as BaseAbstractNotification
@@ -18,9 +18,13 @@ class AbstractNotification(BaseAbstractNotification, RelayModel):
         from baseapp_notifications.graphql.subscriptions import OnNotificationChange
 
         if created:
-            OnNotificationChange.send_created_notification(notification=self)
+            transaction.on_commit(
+                lambda: OnNotificationChange.send_created_notification(notification=self)
+            )
         else:
-            OnNotificationChange.send_updated_notification(notification=self)
+            transaction.on_commit(
+                lambda: OnNotificationChange.send_updated_notification(notification=self)
+            )
 
     def delete(self, *args, **kwargs):
         notification_relay_id = self.relay_id

--- a/baseapp_reactions/tests/conftest.py
+++ b/baseapp_reactions/tests/conftest.py
@@ -1,2 +1,10 @@
+from celery import current_app
+
 from baseapp_core.graphql.testing.fixtures import *  # noqa
 from baseapp_core.tests.fixtures import *  # noqa
+
+# Apply Django's CELERY_* settings (including CELERY_TASK_ALWAYS_EAGER=True) to the
+# Celery default_app so .delay() runs synchronously in tests. Must run at module level
+# — a fixture would only configure the app instance on the main thread's task stack,
+# which worker threads (spawned by database_sync_to_async in async tests) can't see.
+current_app.config_from_object("django.conf:settings", namespace="CELERY")

--- a/baseapp_reactions/tests/test_graphql_notification_subscriptions.py
+++ b/baseapp_reactions/tests/test_graphql_notification_subscriptions.py
@@ -1,0 +1,94 @@
+import textwrap
+
+import pytest
+from channels.db import database_sync_to_async
+from django.test import override_settings
+
+from baseapp_comments.tests.factories import CommentFactory
+from baseapp_core.graphql.testing.fixtures import graphql_query
+from baseapp_core.tests.factories import UserFactory
+from baseapp_core.tests.fixtures import DjangoClient
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+NOTIFICATION_SUBSCRIPTION_QUERY = textwrap.dedent("""
+    subscription op_name {
+      onNotificationChange {
+        createdNotification {
+          node {
+            id
+            verb
+            recipient {
+              id
+              notificationsUnreadCount
+            }
+          }
+        }
+      }
+    }
+    """)
+
+REACTION_TOGGLE_GRAPHQL = """
+    mutation ReactionToggleMutation($input: ReactionToggleInput!) {
+        reactionToggle(input: $input) {
+            reaction {
+                node {
+                    id
+                    reactionType
+                }
+            }
+            errors {
+                field
+                messages
+            }
+        }
+    }
+"""
+
+
+@pytest.mark.asyncio
+@override_settings(BASEAPP_REACTIONS_ENABLE_NOTIFICATIONS=True)
+async def test_reaction_created_subscription_has_correct_unread_count(
+    django_user_client, graphql_ws_user_client
+):
+    # Setup: User A (django_user_client.user) owns a comment (the reaction target)
+    target = await database_sync_to_async(CommentFactory)(user=django_user_client.user)
+    target_relay_id = await database_sync_to_async(lambda: target.relay_id)()
+
+    # Subscribe as User A (the target owner who will receive the notification)
+    client = await graphql_ws_user_client(consumer_attrs={"strict_ordering": True})
+    try:
+        sub_id = await client.send(
+            msg_type="subscribe",
+            payload={
+                "query": NOTIFICATION_SUBSCRIPTION_QUERY,
+                "operationName": "op_name",
+            },
+        )
+        await client.assert_no_messages()
+
+        # Action: User B likes User A's comment via mutation
+        liker = await database_sync_to_async(UserFactory)()
+        liker_client = DjangoClient()
+        await database_sync_to_async(liker_client.force_login)(liker)
+
+        response = await database_sync_to_async(graphql_query)(
+            REACTION_TOGGLE_GRAPHQL,
+            variables={
+                "input": {
+                    "targetObjectId": target_relay_id,
+                    "reactionType": "LIKE",
+                }
+            },
+            client=liker_client,
+        )
+        content = response.json()
+        assert "errors" not in content
+
+        # Verify: subscription message has correct verb and unread count
+        resp = await client.receive(assert_id=sub_id, assert_type="next")
+        notification = resp["data"]["onNotificationChange"]["createdNotification"]["node"]
+        assert notification["verb"] == "REACTIONS.REACTION_CREATED"
+        assert notification["recipient"]["notificationsUnreadCount"] == 1
+    finally:
+        await client.finalize()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Notifications for created/updated items are now dispatched after the surrounding database transaction commits, improving delivery reliability.

* **Tests**
  * Added end-to-end tests for GraphQL notification subscriptions covering comments, replies, and reactions to verify notification events and unread counts.
  * Test setup now wires Celery test configuration so background tasks run predictably during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->