### PR TITLE
BA-email-notifications-settings-vars

### DIFF
--- a/baseapp_comments/README.md
+++ b/baseapp_comments/README.md
@@ -79,6 +79,10 @@ BASEAPP_COMMENTS_CAN_ANONYMOUS_VIEW_COMMENTS = True
 BASEAPP_COMMENTS_MAX_PINS_PER_THREAD = None
 BASEAPP_COMMENTS_ENABLE_GRAPHQL_SUBSCRIPTIONS = True
 BASEAPP_COMMENTS_ENABLE_NOTIFICATIONS = True
+# Whether the "comment created" notification is also sent by email.
+BASEAPP_COMMENTS_NOTIFICATION_CREATED_EMAIL = True
+# Whether the "reply created" notification is also sent by email.
+BASEAPP_COMMENTS_NOTIFICATION_REPLY_EMAIL = True
 ```
 
 You need to inherit `CommentableModel` in your model and make sure to add `CommentsInterface` to your ObjectType's interfaces like:

--- a/baseapp_comments/notifications.py
+++ b/baseapp_comments/notifications.py
@@ -1,5 +1,6 @@
 import swapper
 from celery import shared_task
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils.translation import gettext as _
 
@@ -16,7 +17,7 @@ def send_reply_created_notification(comment_pk):
     send_notification(
         add_to_history=True,
         send_push=True,
-        send_email=True,
+        send_email=getattr(settings, "BASEAPP_COMMENTS_NOTIFICATION_REPLY_EMAIL", True),
         sender=comment.profile or comment.user,
         recipient=comment.in_reply_to.user,
         verb="COMMENTS.COMMENT_REPLY_CREATED",
@@ -38,7 +39,7 @@ def send_comment_created_notification(comment_pk, recipient_id):
     send_notification(
         add_to_history=True,
         send_push=True,
-        send_email=True,
+        send_email=getattr(settings, "BASEAPP_COMMENTS_NOTIFICATION_CREATED_EMAIL", True),
         sender=comment.profile or comment.user,
         recipient=recipient,
         verb="COMMENTS.COMMENT_CREATED",

--- a/baseapp_comments/tests/test_notifications.py
+++ b/baseapp_comments/tests/test_notifications.py
@@ -41,3 +41,77 @@ def test_user_receieve_notification_when_reply_is_created():
             comment = CommentFactory(target=target, user=friend, in_reply_to=parent)
             assert mock.called
             assert mock.call_args.args == (comment.pk,)
+
+
+def test_comment_created_notification_sends_email_by_default(outbox):
+    user = UserFactory()
+    friend = UserFactory()
+    target = CommentFactory(user=user)
+
+    with override_settings(
+        BASEAPP_COMMENTS_ENABLE_NOTIFICATIONS=True,
+        BASEAPP_COMMENTS_NOTIFICATION_CREATED_EMAIL=True,
+    ):
+        CommentFactory(target=target, user=friend)
+
+    assert len(outbox) == 1
+    assert outbox[0].to == [user.email]
+    assert Notification.objects.filter(recipient=user, verb="COMMENTS.COMMENT_CREATED").exists()
+
+
+def test_comment_created_notification_skips_email_when_disabled(outbox):
+    user = UserFactory()
+    friend = UserFactory()
+    target = CommentFactory(user=user)
+
+    with override_settings(
+        BASEAPP_COMMENTS_ENABLE_NOTIFICATIONS=True,
+        BASEAPP_COMMENTS_NOTIFICATION_CREATED_EMAIL=False,
+    ):
+        CommentFactory(target=target, user=friend)
+
+    assert len(outbox) == 0
+    # The in-app notification is unaffected — only the email is suppressed.
+    assert Notification.objects.filter(recipient=user, verb="COMMENTS.COMMENT_CREATED").exists()
+
+
+def test_reply_created_notification_sends_email_by_default(outbox):
+    user = UserFactory()
+    friend = UserFactory()
+    # Suppress notifications while building the parent, which would otherwise email its target's owner.
+    with override_settings(BASEAPP_COMMENTS_ENABLE_NOTIFICATIONS=False):
+        target = CommentFactory()
+        parent = CommentFactory(target=target, user=user)
+
+    with override_settings(
+        BASEAPP_COMMENTS_ENABLE_NOTIFICATIONS=True,
+        BASEAPP_COMMENTS_NOTIFICATION_REPLY_EMAIL=True,
+    ):
+        CommentFactory(target=target, user=friend, in_reply_to=parent)
+
+    assert len(outbox) == 1
+    assert outbox[0].to == [user.email]
+    assert Notification.objects.filter(
+        recipient=user, verb="COMMENTS.COMMENT_REPLY_CREATED"
+    ).exists()
+
+
+def test_reply_created_notification_skips_email_when_disabled(outbox):
+    user = UserFactory()
+    friend = UserFactory()
+    # Suppress notifications while building the parent, which would otherwise email its target's owner.
+    with override_settings(BASEAPP_COMMENTS_ENABLE_NOTIFICATIONS=False):
+        target = CommentFactory()
+        parent = CommentFactory(target=target, user=user)
+
+    with override_settings(
+        BASEAPP_COMMENTS_ENABLE_NOTIFICATIONS=True,
+        BASEAPP_COMMENTS_NOTIFICATION_REPLY_EMAIL=False,
+    ):
+        CommentFactory(target=target, user=friend, in_reply_to=parent)
+
+    assert len(outbox) == 0
+    # The in-app notification is unaffected — only the email is suppressed.
+    assert Notification.objects.filter(
+        recipient=user, verb="COMMENTS.COMMENT_REPLY_CREATED"
+    ).exists()

--- a/baseapp_reactions/README.md
+++ b/baseapp_reactions/README.md
@@ -96,6 +96,17 @@ Example:
 }
 ```
 
+## Settings
+
+You can customize the following settings, below are the default values:
+
+```python
+# Master switch for all reaction notifications (in-app, push and email).
+BASEAPP_REACTIONS_ENABLE_NOTIFICATIONS = True
+# Whether the "reaction created" notification is also sent by email.
+BASEAPP_REACTIONS_NOTIFICATION_CREATED_EMAIL = True
+```
+
 ## How to to customize the Reaction model
 
 In some cases you may need to extend Reaction model, and we can do it following the next steps:

--- a/baseapp_reactions/notifications.py
+++ b/baseapp_reactions/notifications.py
@@ -2,6 +2,7 @@ import logging
 
 import swapper
 from celery import shared_task
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils.translation import gettext as _
 
@@ -23,7 +24,7 @@ def send_reaction_created_notification(reaction_pk, recipient_id):
     send_notification(
         add_to_history=True,
         send_push=True,
-        send_email=True,
+        send_email=getattr(settings, "BASEAPP_REACTIONS_NOTIFICATION_CREATED_EMAIL", True),
         sender=reaction.profile or reaction.user,
         recipient=recipient,
         verb="REACTIONS.REACTION_CREATED",

--- a/baseapp_reactions/tests/test_notifications.py
+++ b/baseapp_reactions/tests/test_notifications.py
@@ -26,3 +26,33 @@ def test_user_receives_notification_when_reaction_is_created(graphql_client):
             reaction = ReactionFactory(target=target)
             assert mock.called
             assert mock.call_args.args == (reaction.pk, user.id)
+
+
+def test_reaction_created_notification_sends_email_by_default(outbox):
+    user = UserFactory()
+    target = CommentFactory(user=user)
+
+    with override_settings(
+        BASEAPP_REACTIONS_ENABLE_NOTIFICATIONS=True,
+        BASEAPP_REACTIONS_NOTIFICATION_CREATED_EMAIL=True,
+    ):
+        ReactionFactory(target=target)
+
+    assert len(outbox) == 1
+    assert outbox[0].to == [user.email]
+    assert Notification.objects.filter(recipient=user, verb="REACTIONS.REACTION_CREATED").exists()
+
+
+def test_reaction_created_notification_skips_email_when_disabled(outbox):
+    user = UserFactory()
+    target = CommentFactory(user=user)
+
+    with override_settings(
+        BASEAPP_REACTIONS_ENABLE_NOTIFICATIONS=True,
+        BASEAPP_REACTIONS_NOTIFICATION_CREATED_EMAIL=False,
+    ):
+        ReactionFactory(target=target)
+
+    assert len(outbox) == 0
+    # The in-app notification is unaffected — only the email is suppressed.
+    assert Notification.objects.filter(recipient=user, verb="REACTIONS.REACTION_CREATED").exists()


### PR DESCRIPTION
## Summary

Notification emails for reactions and comments were previously hardcoded to always send
(`send_email=True`). This PR introduces settings so consuming projects can opt out of these
emails (e.g. to reduce noise) while keeping in-app and push notifications intact.

## New settings

All default to `True`, preserving current behavior.

| Setting | Package | Controls |
|---|---|---|
| `BASEAPP_REACTIONS_NOTIFICATION_CREATED_EMAIL` | `baseapp_reactions` | Email for the "reaction created" notification |
| `BASEAPP_COMMENTS_NOTIFICATION_CREATED_EMAIL` | `baseapp_comments` | Email for the "comment created" notification |
| `BASEAPP_COMMENTS_NOTIFICATION_REPLY_EMAIL` | `baseapp_comments` | Email for the "reply created" notification |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable settings to control whether email notifications are sent for comment-created, reply-created, and reaction-created events (enabled by default).

* **Documentation**
  * Updated configuration docs to describe the new notification email settings and defaults.

* **Tests**
  * Added tests verifying email is sent by default, can be disabled, and in-app notifications are still created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->