### PR TITLE
fix(profiles): friendly error when adding an already-existing member

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,14 +60,20 @@ baseapp_<package>/tests/
 
 ## Commands
 
-Run from the consuming project root via Docker Compose:
+Run these from **this submodule's** root (`baseapp-backend/`) using its own `docker-compose.yml`.
+Do **not** use a consuming template's container: it runs the template's `settings.*` (not
+`testproject.settings`) and its pytest config ignores `baseapp-backend`, so package tests won't run
+there. Paths below are relative to the submodule root.
 
 ```bash
 # All tests
 docker compose run --rm web pytest
 
 # Specific package
-docker compose run --rm web pytest baseapp-backend/baseapp_auth/
+docker compose run --rm web pytest baseapp_profiles/tests/
+
+# Reuse the test DB across runs (skips the slow migrate/setup step)
+docker compose run --rm web pytest baseapp_profiles/tests/ --reuse-db
 
 # With coverage
 docker compose run --rm web pytest --cov --cov-report=term-missing

--- a/baseapp_profiles/graphql/mutations/invitations.py
+++ b/baseapp_profiles/graphql/mutations/invitations.py
@@ -249,6 +249,12 @@ class ProfileAcceptInvitation(RelayMutation):
         invitation = _get_invitation_by_token(token)
         _validate_invitation_for_response(invitation, info.context.user)
 
+        if invitation.profile.owner_id == info.context.user.id:
+            raise GraphQLError(
+                str(_("The profile owner cannot accept an invitation to their own profile")),
+                extensions={"code": "cannot_add_owner"},
+            )
+
         invitation.status = ProfileUserRole.ProfileRoleStatus.ACTIVE
         invitation.responded_at = timezone.now()
         invitation.save()

--- a/baseapp_profiles/graphql/mutations/roles.py
+++ b/baseapp_profiles/graphql/mutations/roles.py
@@ -66,6 +66,11 @@ class ProfileUserRoleCreate(RelayMutation):
         requested_user_pks = list(
             dict.fromkeys(get_pk_from_relay_id(user_id) for user_id in (users_ids or []))
         )
+        if str(profile.owner_id) in {str(pk) for pk in requested_user_pks}:
+            raise GraphQLError(
+                str(_("The profile owner cannot be added as a member")),
+                extensions={"code": "cannot_add_owner"},
+            )
         if ProfileUserRole.objects.filter(
             profile_id=profile_pk, user_id__in=requested_user_pks
         ).exists():

--- a/baseapp_profiles/graphql/mutations/roles.py
+++ b/baseapp_profiles/graphql/mutations/roles.py
@@ -1,6 +1,8 @@
+import logging
+
 import graphene
 import swapper
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.utils.translation import gettext_lazy as _
 from graphql.error import GraphQLError
 
@@ -16,6 +18,8 @@ from ..object_types import ProfileRoleTypesEnum
 Profile = swapper.load_model("baseapp_profiles", "Profile")
 ProfileUserRole = swapper.load_model("baseapp_profiles", "ProfileUserRole")
 profile_user_role_app_label = ProfileUserRole._meta.app_label
+
+logger = logging.getLogger(__name__)
 
 
 class ProfileUserRoleCreate(RelayMutation):
@@ -57,15 +61,33 @@ class ProfileUserRoleCreate(RelayMutation):
         if emails_to_invite:
             pass
 
-        profile_user_roles = [
-            ProfileUserRole(
-                user_id=get_pk_from_relay_id(user_id), profile_id=profile_pk, role=role_type
+        # De-duplicate the requested users, then reject any that are already members so the
+        # client gets a clear message instead of a raw unique-constraint (IntegrityError).
+        requested_user_pks = list(
+            dict.fromkeys(get_pk_from_relay_id(user_id) for user_id in (users_ids or []))
+        )
+        if ProfileUserRole.objects.filter(
+            profile_id=profile_pk, user_id__in=requested_user_pks
+        ).exists():
+            raise GraphQLError(
+                str(_("One or more of the selected users are already members of this profile")),
+                extensions={"code": "already_member"},
             )
-            for user_id in (users_ids or [])
-        ]
-        profile_user_roles = ProfileUserRole.objects.bulk_create(profile_user_roles)
 
-        # TODO on BA-2426: send invitation to existing users
+        try:
+            profile_user_roles = ProfileUserRole.objects.bulk_create(
+                [
+                    ProfileUserRole(user_id=user_pk, profile_id=profile_pk, role=role_type)
+                    for user_pk in requested_user_pks
+                ]
+            )
+        except IntegrityError:
+            # Safety net for a race between the check above and the insert.
+            logger.exception("Failed to add members to profile %s", profile_pk)
+            raise GraphQLError(
+                str(_("One or more of the selected users are already members of this profile")),
+                extensions={"code": "already_member"},
+            )
 
         return cls(
             errors=None,

--- a/baseapp_profiles/graphql/mutations/roles.py
+++ b/baseapp_profiles/graphql/mutations/roles.py
@@ -75,19 +75,28 @@ class ProfileUserRoleCreate(RelayMutation):
             )
 
         try:
-            profile_user_roles = ProfileUserRole.objects.bulk_create(
-                [
-                    ProfileUserRole(user_id=user_pk, profile_id=profile_pk, role=role_type)
-                    for user_pk in requested_user_pks
-                ]
-            )
-        except IntegrityError:
-            # Safety net for a race between the check above and the insert.
+            with transaction.atomic():
+                profile_user_roles = ProfileUserRole.objects.bulk_create(
+                    [
+                        ProfileUserRole(user_id=user_pk, profile_id=profile_pk, role=role_type)
+                        for user_pk in requested_user_pks
+                    ]
+                )
+        except IntegrityError as error:
             logger.exception("Failed to add members to profile %s", profile_pk)
+            # Only report "already_member" if a membership actually exists now (race with the
+            # pre-check); any other integrity failure returns a generic error.
+            if ProfileUserRole.objects.filter(
+                profile_id=profile_pk, user_id__in=requested_user_pks
+            ).exists():
+                raise GraphQLError(
+                    str(_("One or more of the selected users are already members of this profile")),
+                    extensions={"code": "already_member"},
+                ) from error
             raise GraphQLError(
-                str(_("One or more of the selected users are already members of this profile")),
-                extensions={"code": "already_member"},
-            )
+                str(_("Unable to add the selected members")),
+                extensions={"code": "add_member_failed"},
+            ) from error
 
         return cls(
             errors=None,

--- a/baseapp_profiles/tests/test_graphql_mutations_create.py
+++ b/baseapp_profiles/tests/test_graphql_mutations_create.py
@@ -1,0 +1,86 @@
+import pytest
+import swapper
+from django.contrib.auth.models import Permission
+
+from baseapp_core.tests.factories import UserFactory
+
+from .factories import ProfileFactory, ProfileUserRoleFactory
+
+pytestmark = pytest.mark.django_db
+
+Profile = swapper.load_model("baseapp_profiles", "Profile")
+ProfileUserRole = swapper.load_model("baseapp_profiles", "ProfileUserRole")
+
+
+PROFILE_USER_ROLE_CREATE_GRAPHQL = """
+mutation ProfileUserRoleCreateMutation($input: ProfileUserRoleCreateInput!) {
+    profileUserRoleCreate(input: $input) {
+        profileUserRoles {
+            id
+            role
+            status
+        }
+    }
+}
+"""
+
+
+def _add_member_permission(user):
+    perm = Permission.objects.get(
+        content_type__app_label=ProfileUserRole._meta.app_label, codename="add_profileuserrole"
+    )
+    user.user_permissions.add(perm)
+
+
+def test_user_with_permission_can_add_member(django_user_client, graphql_user_client):
+    user = django_user_client.user
+    _add_member_permission(user)
+    profile = ProfileFactory(owner=user)
+    new_member = UserFactory()
+
+    response = graphql_user_client(
+        PROFILE_USER_ROLE_CREATE_GRAPHQL,
+        variables={
+            "input": {
+                "profileId": profile.relay_id,
+                "usersIds": [new_member.relay_id],
+                "roleType": "MANAGER",
+            }
+        },
+    )
+    content = response.json()
+
+    assert "errors" not in content, content.get("errors")
+    roles = content["data"]["profileUserRoleCreate"]["profileUserRoles"]
+    assert len(roles) == 1
+    assert ProfileUserRole.objects.filter(profile=profile, user=new_member).exists()
+
+
+def test_adding_an_existing_member_returns_a_friendly_error(
+    django_user_client, graphql_user_client
+):
+    user = django_user_client.user
+    _add_member_permission(user)
+    profile = ProfileFactory(owner=user)
+    existing_member = UserFactory()
+    ProfileUserRoleFactory(
+        profile=profile, user=existing_member, role=ProfileUserRole.ProfileRoles.MANAGER
+    )
+
+    response = graphql_user_client(
+        PROFILE_USER_ROLE_CREATE_GRAPHQL,
+        variables={
+            "input": {
+                "profileId": profile.relay_id,
+                "usersIds": [existing_member.relay_id],
+                "roleType": "MANAGER",
+            }
+        },
+    )
+    content = response.json()
+
+    assert content["errors"][0]["extensions"]["code"] == "already_member"
+    # The raw unique-constraint / DB error must never reach the client.
+    assert "duplicate key" not in content["errors"][0]["message"]
+    # No duplicate row was created.
+    assert ProfileUserRole.objects.filter(profile=profile, user=existing_member).count() == 1

--- a/baseapp_profiles/tests/test_graphql_mutations_create.py
+++ b/baseapp_profiles/tests/test_graphql_mutations_create.py
@@ -139,3 +139,24 @@ def test_integrity_error_that_is_not_a_duplicate_returns_a_generic_error(
 
     assert content["errors"][0]["extensions"]["code"] == "add_member_failed"
     assert not ProfileUserRole.objects.filter(profile=profile, user=new_member).exists()
+
+
+def test_cannot_add_the_owner_as_a_member(django_user_client, graphql_user_client):
+    user = django_user_client.user
+    _add_member_permission(user)
+    profile = ProfileFactory(owner=user)
+
+    response = graphql_user_client(
+        PROFILE_USER_ROLE_CREATE_GRAPHQL,
+        variables={
+            "input": {
+                "profileId": profile.relay_id,
+                "usersIds": [user.relay_id],
+                "roleType": "MANAGER",
+            }
+        },
+    )
+    content = response.json()
+
+    assert content["errors"][0]["extensions"]["code"] == "cannot_add_owner"
+    assert not ProfileUserRole.objects.filter(profile=profile, user=user).exists()

--- a/baseapp_profiles/tests/test_graphql_mutations_create.py
+++ b/baseapp_profiles/tests/test_graphql_mutations_create.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 import pytest
 import swapper
 from django.contrib.auth.models import Permission
+from django.db import IntegrityError
 
 from baseapp_core.tests.factories import UserFactory
 
@@ -8,7 +11,6 @@ from .factories import ProfileFactory, ProfileUserRoleFactory
 
 pytestmark = pytest.mark.django_db
 
-Profile = swapper.load_model("baseapp_profiles", "Profile")
 ProfileUserRole = swapper.load_model("baseapp_profiles", "ProfileUserRole")
 
 
@@ -84,3 +86,56 @@ def test_adding_an_existing_member_returns_a_friendly_error(
     assert "duplicate key" not in content["errors"][0]["message"]
     # No duplicate row was created.
     assert ProfileUserRole.objects.filter(profile=profile, user=existing_member).count() == 1
+
+
+def test_duplicate_user_ids_in_one_request_create_a_single_membership(
+    django_user_client, graphql_user_client
+):
+    user = django_user_client.user
+    _add_member_permission(user)
+    profile = ProfileFactory(owner=user)
+    new_member = UserFactory()
+
+    response = graphql_user_client(
+        PROFILE_USER_ROLE_CREATE_GRAPHQL,
+        variables={
+            "input": {
+                "profileId": profile.relay_id,
+                "usersIds": [new_member.relay_id, new_member.relay_id],
+                "roleType": "MANAGER",
+            }
+        },
+    )
+    content = response.json()
+
+    assert "errors" not in content, content.get("errors")
+    roles = content["data"]["profileUserRoleCreate"]["profileUserRoles"]
+    assert len(roles) == 1
+    assert ProfileUserRole.objects.filter(profile=profile, user=new_member).count() == 1
+
+
+def test_integrity_error_that_is_not_a_duplicate_returns_a_generic_error(
+    django_user_client, graphql_user_client
+):
+    user = django_user_client.user
+    _add_member_permission(user)
+    profile = ProfileFactory(owner=user)
+    new_member = UserFactory()
+
+    # An IntegrityError that is not an existing membership (e.g. a FK violation) must return a
+    # generic error, not be misreported as "already_member".
+    with patch.object(ProfileUserRole.objects, "bulk_create", side_effect=IntegrityError("boom")):
+        response = graphql_user_client(
+            PROFILE_USER_ROLE_CREATE_GRAPHQL,
+            variables={
+                "input": {
+                    "profileId": profile.relay_id,
+                    "usersIds": [new_member.relay_id],
+                    "roleType": "MANAGER",
+                }
+            },
+        )
+    content = response.json()
+
+    assert content["errors"][0]["extensions"]["code"] == "add_member_failed"
+    assert not ProfileUserRole.objects.filter(profile=profile, user=new_member).exists()

--- a/baseapp_profiles/tests/test_invitations.py
+++ b/baseapp_profiles/tests/test_invitations.py
@@ -215,6 +215,40 @@ class TestInvitationMutations:
         assert invitation.status == ProfileUserRole.ProfileRoleStatus.ACTIVE
         assert invitation.responded_at is not None
 
+    def test_owner_cannot_accept_invitation_to_their_own_profile(
+        self, django_user_client, graphql_user_client
+    ):
+        owner = django_user_client.user
+        profile = ProfileFactory(owner=owner)
+
+        invitation = create_invitation(
+            profile=profile,
+            inviter=owner,
+            invited_email=owner.email,
+            role=ProfileUserRole.ProfileRoles.MANAGER,
+        )
+
+        mutation = """
+            mutation AcceptInvitation($input: ProfileAcceptInvitationInput!) {
+                profileAcceptInvitation(input: $input) {
+                    profileUserRole {
+                        id
+                        status
+                    }
+                }
+            }
+        """
+
+        variables = {"input": {"token": invitation.invitation_token}}
+
+        response = graphql_user_client(mutation, variables=variables)
+        content = response.json()
+
+        assert content["errors"][0]["extensions"]["code"] == "cannot_add_owner"
+
+        invitation.refresh_from_db()
+        assert invitation.status == ProfileUserRole.ProfileRoleStatus.PENDING
+
     def test_decline_profile_invitation_mutation(self, django_user_client, graphql_user_client):
         owner = UserFactory()
         profile = ProfileFactory(owner=owner)


### PR DESCRIPTION
### Problem
`profileUserRoleCreate` did an unguarded `bulk_create`, so re-adding a user who is already a member returned the **raw Postgres unique-constraint violation** to the client:

> duplicate key value violates unique constraint "profiles_profileuserrole_user_id_profile_id_..." … Key (user_id, profile_id)=(4, 2) already exists.

That leaks DB internals and is not human-friendly (violates the "catch exceptions, return a generic error, never expose details" guideline).

### Fix
- De-duplicate the requested `usersIds`, then reject any that are already members with a clean `GraphQLError` (`code: "already_member"`) — consistent with `profileSendInvitation`'s duplicate handling.
- Keep a caught `IntegrityError` as a race safety net (logged, generic message).
- Add `test_graphql_mutations_create.py` covering the success path and the duplicate → `already_member` path (asserting the raw "duplicate key" text never reaches the client).

All profiles mutation tests pass (63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate profile membership entries by deduplicating repeated member IDs in a single request.
  * Added clearer errors when a member already belongs, including safer handling of race-condition insert failures.
  * Blocked adding the profile owner as a member with a dedicated error.
* **Tests**
  * Expanded GraphQL mutation tests for duplicates, existing members, non-duplicate integrity failures, and owner-rejection.
* **Documentation**
  * Updated backend test-running instructions, including guidance for reusing the test database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->