### PR TITLE
Add contact to multiple groups

### DIFF
--- a/baseapp_chats/graphql/filters.py
+++ b/baseapp_chats/graphql/filters.py
@@ -1,6 +1,6 @@
 import django_filters
 import swapper
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 
 from baseapp_core.graphql import get_pk_from_relay_id
 
@@ -13,13 +13,22 @@ class ChatRoomFilter(django_filters.FilterSet):
     profile_id = django_filters.CharFilter(method="filter_profile_id")
     unread_messages = django_filters.BooleanFilter(method="filter_unread_messages")
     archived = django_filters.BooleanFilter(method="filter_archived")
+    manageable = django_filters.BooleanFilter(method="filter_manageable")
 
     order_by = django_filters.OrderingFilter(fields=(("created", "created"),))
     is_group = django_filters.BooleanFilter()
 
     class Meta:
         model = ChatRoom
-        fields = ["q", "order_by", "profile_id", "unread_messages", "archived", "is_group"]
+        fields = [
+            "q",
+            "order_by",
+            "profile_id",
+            "unread_messages",
+            "archived",
+            "is_group",
+            "manageable",
+        ]
 
     def filter_q(self, queryset, name, value):
         if not value:
@@ -77,6 +86,25 @@ class ChatRoomFilter(django_filters.FilterSet):
 
         return queryset.filter(
             participants__profile_id=user_profile.pk, participants__has_archived_room=value
+        ).distinct()
+
+    def filter_manageable(self, queryset: QuerySet, name: str, value: bool) -> QuerySet:
+        """Narrow to group rooms where the current profile has the ADMIN role."""
+        if not value:
+            return queryset
+
+        try:
+            user_profile = self.request.user.current_profile
+        except AttributeError:
+            return queryset.none()
+
+        if not user_profile:
+            return queryset.none()
+
+        return queryset.filter(
+            is_group=True,
+            participants__profile_id=user_profile.pk,
+            participants__role=ChatRoomParticipant.ChatRoomParticipantRoles.ADMIN,
         ).distinct()
 
 

--- a/baseapp_chats/graphql/mutations.py
+++ b/baseapp_chats/graphql/mutations.py
@@ -2,7 +2,7 @@ import graphene
 import swapper
 from django.contrib.auth import get_user_model
 from django.db import transaction
-from django.db.models import Count, Q
+from django.db.models import Count
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from graphene_django.types import ErrorType
@@ -17,6 +17,7 @@ from baseapp_chats.graphql.subscriptions import (
 from baseapp_chats.utils import (
     SYSTEM_MESSAGE_GROUP_CREATED,
     SYSTEM_MESSAGE_MADE_ADMIN,
+    add_profiles_to_room,
     escape_format_braces,
     send_chatroom_update_system_messages,
     send_message,
@@ -345,28 +346,7 @@ class ChatRoomUpdate(RelayMutation):
                     oldest_remaining_participant.save(update_fields=["role"])
 
             # Adding new participants
-            unique_participants_pks = list(set(add_participants_pks))
-            existing_participants_pks = ChatRoomParticipant.objects.filter(
-                Q(room=room) & Q(profile__pk__in=unique_participants_pks)
-            ).values_list("profile__pk", flat=True)
-
-            new_participants = [
-                participant
-                for participant in unique_participants_pks
-                if int(participant) not in existing_participants_pks
-            ]
-
-            created_participants = ChatRoomParticipant.objects.bulk_create(
-                [
-                    ChatRoomParticipant(
-                        profile_id=participant,
-                        room=room,
-                        role=ChatRoomParticipantRoles.MEMBER,
-                        accepted_at=timezone.now(),
-                    )
-                    for participant in new_participants
-                ]
-            )
+            created_participants = add_profiles_to_room(room, add_participants_pks)
 
             room.participants_count = (
                 room.participants_count - len(removed_participants) + len(created_participants)
@@ -401,6 +381,164 @@ class ChatRoomUpdate(RelayMutation):
             ),
             removed_participants=removed_participants,
             added_participants=created_participants,
+        )
+
+
+class ChatRoomsAddParticipant(RelayMutation):
+    """Add one profile as a MEMBER participant to multiple group chat rooms at once.
+
+    All-or-nothing: if the acting profile can't add participants to any of the
+    requested rooms, nothing is written. Rooms where the profile is already a
+    participant are silently skipped (idempotent).
+    """
+
+    rooms = graphene.List(
+        ChatRoomObjectType,
+        description="All requested rooms, after the update.",
+    )
+    added_participants = graphene.List(
+        ChatRoomParticipantObjectType,
+        description="Participant rows actually created (already-member rooms are skipped).",
+    )
+
+    class Input:
+        profile_id = graphene.ID(
+            required=True, description="Relay id of the acting profile (must be manageable)."
+        )
+        participant_profile_id = graphene.ID(
+            required=True, description="Relay id of the profile to add to the rooms."
+        )
+        room_ids = graphene.List(
+            graphene.NonNull(graphene.ID),
+            required=True,
+            description="Relay ids of the group rooms to add the participant to.",
+        )
+
+    @classmethod
+    @login_required
+    def mutate_and_get_payload(
+        cls,
+        root,
+        info: graphene.ResolveInfo,
+        profile_id: str,
+        participant_profile_id: str,
+        room_ids: list[str],
+        **input,
+    ) -> "ChatRoomsAddParticipant":
+        profile = get_obj_from_relay_id(info, profile_id)
+
+        if not info.context.user.has_perm(f"{profile_app_label}.use_profile", profile):
+            return ChatRoomsAddParticipant(
+                errors=[
+                    ErrorType(
+                        field="profile_id",
+                        messages=[_("You don't have permission to act as this profile")],
+                    )
+                ]
+            )
+
+        try:
+            participant_profile = get_obj_from_relay_id(info, participant_profile_id)
+        except Exception:
+            participant_profile = None
+        if not isinstance(participant_profile, Profile):
+            return ChatRoomsAddParticipant(
+                errors=[
+                    ErrorType(
+                        field="participant_profile_id",
+                        messages=[_("This profile is not valid")],
+                    )
+                ]
+            )
+
+        # Check if the participant is blocked
+        if service := shared_services.get("blocks.lookup"):
+            if service.has_block_between([profile.id], [participant_profile.pk]):
+                return ChatRoomsAddParticipant(
+                    errors=[
+                        ErrorType(
+                            field="participant_profile_id",
+                            messages=[_("You can't add this participant to a chatroom")],
+                        )
+                    ]
+                )
+
+        # Resolve and validate every room before any write (all-or-nothing)
+        rooms = []
+        seen_room_pks = set()
+        for room_id in room_ids:
+            try:
+                room = get_obj_from_relay_id(info, room_id)
+            except Exception:
+                room = None
+            if not room or not isinstance(room, ChatRoom):
+                return ChatRoomsAddParticipant(
+                    errors=[
+                        ErrorType(
+                            field="room_ids",
+                            messages=[_("Some rooms are not valid")],
+                        )
+                    ]
+                )
+
+            if room.pk in seen_room_pks:
+                continue
+            seen_room_pks.add(room.pk)
+
+            if not info.context.user.has_perm(
+                "baseapp_chats.modify_chatroom",
+                {
+                    "profile": profile,
+                    "room": room,
+                    "add_participants": [participant_profile.pk],
+                },
+            ):
+                return ChatRoomsAddParticipant(
+                    errors=[
+                        ErrorType(
+                            field="room_ids",
+                            messages=[
+                                _(
+                                    "You don't have permission to add participants to one or "
+                                    "more of the selected rooms"
+                                )
+                            ],
+                        )
+                    ]
+                )
+
+            rooms.append(room)
+
+        if not rooms:
+            return ChatRoomsAddParticipant(
+                errors=[
+                    ErrorType(
+                        field="room_ids",
+                        messages=[_("You need to select at least one room")],
+                    )
+                ]
+            )
+
+        added_participants = []
+        rooms_with_new_participant = []
+        with transaction.atomic():
+            for room in rooms:
+                created_participants = add_profiles_to_room(room, [participant_profile.pk])
+                if created_participants:
+                    room.participants_count = room.participants_count + len(created_participants)
+                    room.save(update_fields=["participants_count"])
+                    added_participants.extend(created_participants)
+                    rooms_with_new_participant.append((room, created_participants))
+
+        for room, created_participants in rooms_with_new_participant:
+            ChatRoomOnRoomUpdate.room_updated(room, added_participants=created_participants)
+            send_chatroom_update_system_messages(
+                room, profile, added_participants=created_participants
+            )
+
+        return ChatRoomsAddParticipant(
+            rooms=rooms,
+            added_participants=added_participants,
         )
 
 
@@ -934,6 +1072,7 @@ class ChatRoomArchive(RelayMutation):
 class ChatsMutations(object):
     chat_room_create = ChatRoomCreate.Field()
     chat_room_update = ChatRoomUpdate.Field()
+    chat_rooms_add_participant = ChatRoomsAddParticipant.Field()
     chat_room_send_message = ChatRoomSendMessage.Field()
     chat_room_edit_message = ChatRoomEditMessage.Field()
     chat_room_delete_message = ChatRoomDeleteMessage.Field()

--- a/baseapp_chats/graphql/mutations.py
+++ b/baseapp_chats/graphql/mutations.py
@@ -1,8 +1,10 @@
+import logging
+
 import graphene
 import swapper
 from django.contrib.auth import get_user_model
 from django.db import transaction
-from django.db.models import Count
+from django.db.models import Count, Model
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from graphene_django.types import ErrorType
@@ -31,6 +33,8 @@ from baseapp_core.graphql import (
     login_required,
 )
 from baseapp_core.plugins import shared_services
+
+logger = logging.getLogger(__name__)
 
 ChatRoom = swapper.load_model("baseapp_chats", "ChatRoom")
 ChatRoomParticipant = swapper.load_model("baseapp_chats", "ChatRoomParticipant")
@@ -415,6 +419,60 @@ class ChatRoomsAddParticipant(RelayMutation):
         )
 
     @classmethod
+    def _resolve_rooms(
+        cls, info: graphene.ResolveInfo, room_ids: list[str]
+    ) -> tuple[list[Model], ErrorType | None]:
+        """Resolve relay ids to unique group ChatRoom instances, preserving input order."""
+        rooms = []
+        seen_room_pks = set()
+        for room_id in room_ids:
+            try:
+                room = get_obj_from_relay_id(info, room_id)
+            except Exception:
+                room = None
+            if not room or not isinstance(room, ChatRoom) or not room.is_group:
+                return [], ErrorType(
+                    field="room_ids",
+                    messages=[_("Some rooms are not valid")],
+                )
+
+            if room.pk in seen_room_pks:
+                continue
+            seen_room_pks.add(room.pk)
+            rooms.append(room)
+
+        return rooms, None
+
+    @classmethod
+    def _check_rooms_permissions(
+        cls,
+        info: graphene.ResolveInfo,
+        profile: Model,
+        participant_profile: Model,
+        rooms: list[Model],
+    ) -> ErrorType | None:
+        """Return an error unless the actor can add the participant to every room."""
+        for room in rooms:
+            if not info.context.user.has_perm(
+                "baseapp_chats.modify_chatroom",
+                {
+                    "profile": profile,
+                    "room": room,
+                    "add_participants": [participant_profile.pk],
+                },
+            ):
+                return ErrorType(
+                    field="room_ids",
+                    messages=[
+                        _(
+                            "You don't have permission to add participants to one or "
+                            "more of the selected rooms"
+                        )
+                    ],
+                )
+        return None
+
+    @classmethod
     @login_required
     def mutate_and_get_payload(
         cls,
@@ -463,51 +521,10 @@ class ChatRoomsAddParticipant(RelayMutation):
                     ]
                 )
 
-        # Resolve and validate every room before any write (all-or-nothing)
-        rooms = []
-        seen_room_pks = set()
-        for room_id in room_ids:
-            try:
-                room = get_obj_from_relay_id(info, room_id)
-            except Exception:
-                room = None
-            if not room or not isinstance(room, ChatRoom):
-                return ChatRoomsAddParticipant(
-                    errors=[
-                        ErrorType(
-                            field="room_ids",
-                            messages=[_("Some rooms are not valid")],
-                        )
-                    ]
-                )
-
-            if room.pk in seen_room_pks:
-                continue
-            seen_room_pks.add(room.pk)
-
-            if not info.context.user.has_perm(
-                "baseapp_chats.modify_chatroom",
-                {
-                    "profile": profile,
-                    "room": room,
-                    "add_participants": [participant_profile.pk],
-                },
-            ):
-                return ChatRoomsAddParticipant(
-                    errors=[
-                        ErrorType(
-                            field="room_ids",
-                            messages=[
-                                _(
-                                    "You don't have permission to add participants to one or "
-                                    "more of the selected rooms"
-                                )
-                            ],
-                        )
-                    ]
-                )
-
-            rooms.append(room)
+        # Resolve every room before any write (all-or-nothing)
+        rooms, resolve_error = cls._resolve_rooms(info, room_ids)
+        if resolve_error:
+            return ChatRoomsAddParticipant(errors=[resolve_error])
 
         if not rooms:
             return ChatRoomsAddParticipant(
@@ -522,6 +539,35 @@ class ChatRoomsAddParticipant(RelayMutation):
         added_participants = []
         rooms_with_new_participant = []
         with transaction.atomic():
+            # Lock the room rows in deterministic pk order to serialize concurrent
+            # participant adds (keeps add_profiles_to_room idempotent and the
+            # participants_count increments lossless under concurrency)
+            locked_rooms_by_pk = {
+                locked_room.pk: locked_room
+                for locked_room in ChatRoom.objects.select_for_update()
+                .filter(pk__in=[room.pk for room in rooms])
+                .order_by("pk")
+            }
+            if len(locked_rooms_by_pk) != len(rooms):
+                return ChatRoomsAddParticipant(
+                    errors=[
+                        ErrorType(
+                            field="room_ids",
+                            messages=[_("Some rooms are not valid")],
+                        )
+                    ]
+                )
+            rooms = [locked_rooms_by_pk[room.pk] for room in rooms]
+
+            # Validate permissions under the lock, before any write, so a
+            # concurrent demotion/removal committed after resolving the rooms
+            # is still taken into account (all-or-nothing)
+            permission_error = cls._check_rooms_permissions(
+                info, profile, participant_profile, rooms
+            )
+            if permission_error:
+                return ChatRoomsAddParticipant(errors=[permission_error])
+
             for room in rooms:
                 created_participants = add_profiles_to_room(room, [participant_profile.pk])
                 if created_participants:
@@ -531,10 +577,17 @@ class ChatRoomsAddParticipant(RelayMutation):
                     rooms_with_new_participant.append((room, created_participants))
 
         for room, created_participants in rooms_with_new_participant:
-            ChatRoomOnRoomUpdate.room_updated(room, added_participants=created_participants)
-            send_chatroom_update_system_messages(
-                room, profile, added_participants=created_participants
-            )
+            # Memberships are already committed: notification failures must not
+            # surface as mutation errors nor block the remaining rooms
+            try:
+                ChatRoomOnRoomUpdate.room_updated(room, added_participants=created_participants)
+                send_chatroom_update_system_messages(
+                    room, profile, added_participants=created_participants
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to send chat room update notifications for room %s", room.pk
+                )
 
         return ChatRoomsAddParticipant(
             rooms=rooms,

--- a/baseapp_chats/graphql/object_types.py
+++ b/baseapp_chats/graphql/object_types.py
@@ -191,6 +191,10 @@ class BaseChatRoomObjectType:
     other_participant = graphene.Field(get_object_type_for_model(ChatRoomParticipant))
     is_sole_admin = graphene.Boolean()
     participant_ids = graphene.List(graphene.ID)
+    is_participant = graphene.Boolean(
+        profile_id=graphene.ID(required=True),
+        description="Whether the given profile is a participant of this room.",
+    )
 
     @classmethod
     def get_node(cls, info, id):
@@ -344,6 +348,23 @@ class BaseChatRoomObjectType:
         )
         return [get_obj_relay_id(profile) for profile in profiles]
 
+    def resolve_is_participant(
+        self, info: graphene.ResolveInfo, profile_id: str, **kwargs: Any
+    ) -> bool | None:
+        # The relay id decode can hit the database (public-id strategy) and the
+        # argument is the same for every row of a listing, so memoize the decoded
+        # pk on the request.
+        cache = getattr(info.context, "_chats_relay_pk_cache", None)
+        if cache is None:
+            cache = {}
+            info.context._chats_relay_pk_cache = cache
+        if profile_id not in cache:
+            cache[profile_id] = get_pk_from_relay_id(profile_id)
+        profile_pk = cache[profile_id]
+        if not profile_pk:
+            return None
+        return self.participants.filter(profile_id=profile_pk).exists()
+
     class Meta:
         interfaces = (RelayNode,)
         model = ChatRoom
@@ -359,6 +380,7 @@ class BaseChatRoomObjectType:
             "other_participant",
             "is_sole_admin",
             "participant_ids",
+            "is_participant",
         )
         filterset_class = ChatRoomFilter
 

--- a/baseapp_chats/tests/test_graphql_mutations.py
+++ b/baseapp_chats/tests/test_graphql_mutations.py
@@ -1,7 +1,10 @@
+from unittest import mock
+
 import pytest
 import swapper
 from django.test.client import MULTIPART_CONTENT
 from django.test.utils import override_settings
+from django.utils import timezone
 
 from baseapp_blocks.tests.factories import BlockFactory
 from baseapp_core.graphql.testing.fixtures import graphql_query
@@ -1933,3 +1936,354 @@ def test_system_messages_disabled(django_user_client, graphql_user_client):
     )
     room_data = response.json()["data"]["chatRoom"]
     assert _system_message_contents(room_data) == []
+
+
+ADD_PARTICIPANT_TO_ROOMS_GRAPHQL = """
+    mutation ChatRoomsAddParticipantMutation(
+        $input: ChatRoomsAddParticipantInput!
+        $participantProfileId: ID!
+    ) {
+        chatRoomsAddParticipant(input: $input) {
+            rooms {
+                id
+                participantsCount
+                isParticipant(profileId: $participantProfileId)
+            }
+            addedParticipants {
+                id
+                profile {
+                    id
+                }
+            }
+            errors {
+                field
+                messages
+            }
+        }
+    }
+"""
+
+
+def _make_group(profile, role=ChatRoomParticipantRoles.ADMIN, members=()):
+    """Create a group room with profile in the given role plus extra member profiles."""
+    room = ChatRoomFactory(is_group=True, title="group")
+    ChatRoomParticipantFactory(room=room, profile=profile, role=role, accepted_at=timezone.now())
+    for member in members:
+        ChatRoomParticipantFactory(
+            room=room,
+            profile=member,
+            role=ChatRoomParticipantRoles.MEMBER,
+            accepted_at=timezone.now(),
+        )
+    room.participants_count = 1 + len(members)
+    room.save(update_fields=["participants_count"])
+    return room
+
+
+def test_admin_can_add_participant_to_multiple_rooms(django_user_client, graphql_user_client):
+    contact = ProfileFactory(name="Contact Person")
+    my_profile = django_user_client.user.profile
+    room_1 = _make_group(my_profile, members=[ProfileFactory()])
+    room_2 = _make_group(my_profile, members=[ProfileFactory()])
+
+    response = graphql_user_client(
+        ADD_PARTICIPANT_TO_ROOMS_GRAPHQL,
+        variables={
+            "input": {
+                "profileId": my_profile.relay_id,
+                "participantProfileId": contact.relay_id,
+                "roomIds": [room_1.relay_id, room_2.relay_id],
+            },
+            "participantProfileId": contact.relay_id,
+        },
+    )
+    content = response.json()
+    data = content["data"]["chatRoomsAddParticipant"]
+
+    assert data["errors"] is None
+    assert len(data["rooms"]) == 2
+    assert all(room["participantsCount"] == 3 for room in data["rooms"])
+    assert all(room["isParticipant"] is True for room in data["rooms"])
+    assert len(data["addedParticipants"]) == 2
+    assert all(
+        participant["profile"]["id"] == contact.relay_id
+        for participant in data["addedParticipants"]
+    )
+    assert ChatRoomParticipant.objects.filter(profile=contact, room=room_1).exists()
+    assert ChatRoomParticipant.objects.filter(profile=contact, room=room_2).exists()
+    room_1.refresh_from_db()
+    room_2.refresh_from_db()
+    assert room_1.participants_count == 3
+    assert room_2.participants_count == 3
+
+
+def test_add_participant_skips_rooms_where_already_member(django_user_client, graphql_user_client):
+    contact = ProfileFactory(name="Contact Person")
+    my_profile = django_user_client.user.profile
+    room_new = _make_group(my_profile, members=[ProfileFactory()])
+    room_existing = _make_group(my_profile, members=[contact])
+
+    response = graphql_user_client(
+        ADD_PARTICIPANT_TO_ROOMS_GRAPHQL,
+        variables={
+            "input": {
+                "profileId": my_profile.relay_id,
+                "participantProfileId": contact.relay_id,
+                "roomIds": [room_new.relay_id, room_existing.relay_id],
+            },
+            "participantProfileId": contact.relay_id,
+        },
+    )
+    content = response.json()
+    data = content["data"]["chatRoomsAddParticipant"]
+
+    assert data["errors"] is None
+    assert len(data["rooms"]) == 2
+    assert len(data["addedParticipants"]) == 1
+    assert ChatRoomParticipant.objects.filter(profile=contact, room=room_existing).count() == 1
+    room_existing.refresh_from_db()
+    assert room_existing.participants_count == 2
+
+
+def test_add_participant_all_or_nothing_when_not_admin_in_one_room(
+    django_user_client, graphql_user_client
+):
+    contact = ProfileFactory(name="Contact Person")
+    my_profile = django_user_client.user.profile
+    room_admin = _make_group(my_profile, members=[ProfileFactory()])
+    room_member = _make_group(
+        ProfileFactory(), members=[my_profile]
+    )  # someone else is admin, I'm member
+
+    response = graphql_user_client(
+        ADD_PARTICIPANT_TO_ROOMS_GRAPHQL,
+        variables={
+            "input": {
+                "profileId": my_profile.relay_id,
+                "participantProfileId": contact.relay_id,
+                "roomIds": [room_admin.relay_id, room_member.relay_id],
+            },
+            "participantProfileId": contact.relay_id,
+        },
+    )
+    content = response.json()
+    data = content["data"]["chatRoomsAddParticipant"]
+
+    assert data["errors"][0]["field"] == "room_ids"
+    assert not ChatRoomParticipant.objects.filter(profile=contact).exists()
+
+
+def test_cannot_add_participant_to_non_group_room(django_user_client, graphql_user_client):
+    contact = ProfileFactory(name="Contact Person")
+    my_profile = django_user_client.user.profile
+    friend = ProfileFactory()
+    room = ChatRoomFactory(is_group=False, participants_count=2)
+    ChatRoomParticipantFactory(room=room, profile=my_profile, role=ChatRoomParticipantRoles.ADMIN)
+    ChatRoomParticipantFactory(room=room, profile=friend, role=ChatRoomParticipantRoles.MEMBER)
+
+    response = graphql_user_client(
+        ADD_PARTICIPANT_TO_ROOMS_GRAPHQL,
+        variables={
+            "input": {
+                "profileId": my_profile.relay_id,
+                "participantProfileId": contact.relay_id,
+                "roomIds": [room.relay_id],
+            },
+            "participantProfileId": contact.relay_id,
+        },
+    )
+    content = response.json()
+    data = content["data"]["chatRoomsAddParticipant"]
+
+    assert data["errors"][0]["field"] == "room_ids"
+    assert not ChatRoomParticipant.objects.filter(profile=contact).exists()
+
+
+def test_cannot_add_blocked_participant(django_user_client, graphql_user_client):
+    contact = ProfileFactory(name="Contact Person")
+    my_profile = django_user_client.user.profile
+    room = _make_group(my_profile, members=[ProfileFactory()])
+    BlockFactory(actor=my_profile, target=contact)
+
+    response = graphql_user_client(
+        ADD_PARTICIPANT_TO_ROOMS_GRAPHQL,
+        variables={
+            "input": {
+                "profileId": my_profile.relay_id,
+                "participantProfileId": contact.relay_id,
+                "roomIds": [room.relay_id],
+            },
+            "participantProfileId": contact.relay_id,
+        },
+    )
+    content = response.json()
+    data = content["data"]["chatRoomsAddParticipant"]
+
+    assert data["errors"][0]["field"] == "participant_profile_id"
+    assert not ChatRoomParticipant.objects.filter(profile=contact).exists()
+
+
+def test_cannot_add_participant_acting_as_unowned_profile(django_user_client, graphql_user_client):
+    contact = ProfileFactory(name="Contact Person")
+    other_profile = ProfileFactory()
+    room = _make_group(other_profile, members=[ProfileFactory()])
+
+    response = graphql_user_client(
+        ADD_PARTICIPANT_TO_ROOMS_GRAPHQL,
+        variables={
+            "input": {
+                "profileId": other_profile.relay_id,
+                "participantProfileId": contact.relay_id,
+                "roomIds": [room.relay_id],
+            },
+            "participantProfileId": contact.relay_id,
+        },
+    )
+    content = response.json()
+    data = content["data"]["chatRoomsAddParticipant"]
+
+    assert data["errors"][0]["field"] == "profile_id"
+    assert not ChatRoomParticipant.objects.filter(profile=contact).exists()
+
+
+def test_add_participant_invalid_ids_return_errors(django_user_client, graphql_user_client):
+    contact = ProfileFactory(name="Contact Person")
+    my_profile = django_user_client.user.profile
+    room = _make_group(my_profile, members=[ProfileFactory()])
+
+    # invalid room id
+    response = graphql_user_client(
+        ADD_PARTICIPANT_TO_ROOMS_GRAPHQL,
+        variables={
+            "input": {
+                "profileId": my_profile.relay_id,
+                "participantProfileId": contact.relay_id,
+                "roomIds": ["invalid-id"],
+            },
+            "participantProfileId": contact.relay_id,
+        },
+    )
+    data = response.json()["data"]["chatRoomsAddParticipant"]
+    assert data["errors"][0]["field"] == "room_ids"
+
+    # participant id pointing to a non-profile node (a room id)
+    response = graphql_user_client(
+        ADD_PARTICIPANT_TO_ROOMS_GRAPHQL,
+        variables={
+            "input": {
+                "profileId": my_profile.relay_id,
+                "participantProfileId": room.relay_id,
+                "roomIds": [room.relay_id],
+            },
+            "participantProfileId": contact.relay_id,
+        },
+    )
+    data = response.json()["data"]["chatRoomsAddParticipant"]
+    assert data["errors"][0]["field"] == "participant_profile_id"
+
+    # empty room list
+    response = graphql_user_client(
+        ADD_PARTICIPANT_TO_ROOMS_GRAPHQL,
+        variables={
+            "input": {
+                "profileId": my_profile.relay_id,
+                "participantProfileId": contact.relay_id,
+                "roomIds": [],
+            },
+            "participantProfileId": contact.relay_id,
+        },
+    )
+    data = response.json()["data"]["chatRoomsAddParticipant"]
+    assert data["errors"][0]["field"] == "room_ids"
+    assert not ChatRoomParticipant.objects.filter(profile=contact).exists()
+
+
+def test_add_participant_emits_system_message_only_for_newly_added_rooms(
+    django_user_client, graphql_user_client
+):
+    contact = ProfileFactory(name="Contact Person")
+    my_profile = django_user_client.user.profile
+    room_new = _make_group(my_profile, members=[ProfileFactory()])
+    room_existing = _make_group(my_profile, members=[contact])
+
+    graphql_user_client(
+        ADD_PARTICIPANT_TO_ROOMS_GRAPHQL,
+        variables={
+            "input": {
+                "profileId": my_profile.relay_id,
+                "participantProfileId": contact.relay_id,
+                "roomIds": [room_new.relay_id, room_existing.relay_id],
+            },
+            "participantProfileId": contact.relay_id,
+        },
+    )
+
+    added_message = f"You added {contact.name}"
+
+    response = graphql_user_client(
+        ROOM_GRAPHQL,
+        variables={"profileId": my_profile.relay_id, "roomId": room_new.relay_id},
+    )
+    assert added_message in _system_message_contents(response.json()["data"]["chatRoom"])
+
+    response = graphql_user_client(
+        ROOM_GRAPHQL,
+        variables={"profileId": my_profile.relay_id, "roomId": room_existing.relay_id},
+    )
+    assert added_message not in _system_message_contents(response.json()["data"]["chatRoom"])
+
+
+def test_add_participant_broadcasts_room_updated(django_user_client, graphql_user_client):
+    contact = ProfileFactory(name="Contact Person")
+    my_profile = django_user_client.user.profile
+    room_new = _make_group(my_profile, members=[ProfileFactory()])
+    room_existing = _make_group(my_profile, members=[contact])
+
+    with mock.patch(
+        "baseapp_chats.graphql.mutations.ChatRoomOnRoomUpdate.room_updated"
+    ) as room_updated_mock:
+        graphql_user_client(
+            ADD_PARTICIPANT_TO_ROOMS_GRAPHQL,
+            variables={
+                "input": {
+                    "profileId": my_profile.relay_id,
+                    "participantProfileId": contact.relay_id,
+                    "roomIds": [room_new.relay_id, room_existing.relay_id],
+                },
+                "participantProfileId": contact.relay_id,
+            },
+        )
+
+    # Broadcasts fire only for the room that actually gained the participant.
+    # (The system message emitted for that room triggers a second room_updated
+    # via ChatRoomOnRoomUpdate.new_message — also scoped to the same room.)
+    assert room_updated_mock.call_count >= 1
+    assert all(call.args[0].pk == room_new.pk for call in room_updated_mock.call_args_list)
+    added_calls = [
+        call for call in room_updated_mock.call_args_list if call.kwargs.get("added_participants")
+    ]
+    assert len(added_calls) == 1
+    added = added_calls[0].kwargs["added_participants"]
+    assert len(added) == 1
+    assert added[0].profile_id == contact.pk
+
+
+def test_add_participant_requires_authentication(django_client):
+    contact = ProfileFactory(name="Contact Person")
+    room = ChatRoomFactory(is_group=True)
+
+    response = graphql_query(
+        ADD_PARTICIPANT_TO_ROOMS_GRAPHQL,
+        variables={
+            "input": {
+                "profileId": contact.relay_id,
+                "participantProfileId": contact.relay_id,
+                "roomIds": [room.relay_id],
+            },
+            "participantProfileId": contact.relay_id,
+        },
+        client=django_client,
+    )
+    content = response.json()
+    assert content["errors"]
+    assert not ChatRoomParticipant.objects.filter(profile=contact).exists()

--- a/baseapp_chats/tests/test_graphql_mutations.py
+++ b/baseapp_chats/tests/test_graphql_mutations.py
@@ -2195,6 +2195,24 @@ def test_add_participant_invalid_ids_return_errors(django_user_client, graphql_u
     )
     data = response.json()["data"]["chatRoomsAddParticipant"]
     assert data["errors"][0]["field"] == "room_ids"
+
+    # direct (non-group) room among the targets: all-or-nothing rejection
+    direct_room = ChatRoomFactory(created_by=django_user_client.user, is_group=False)
+    response = graphql_user_client(
+        ADD_PARTICIPANT_TO_ROOMS_GRAPHQL,
+        variables={
+            "input": {
+                "profileId": my_profile.relay_id,
+                "participantProfileId": contact.relay_id,
+                "roomIds": [room.relay_id, direct_room.relay_id],
+            },
+            "participantProfileId": contact.relay_id,
+        },
+    )
+    data = response.json()["data"]["chatRoomsAddParticipant"]
+    assert data["errors"][0]["field"] == "room_ids"
+    assert data["errors"][0]["messages"] == ["Some rooms are not valid"]
+
     assert not ChatRoomParticipant.objects.filter(profile=contact).exists()
 
 
@@ -2266,6 +2284,39 @@ def test_add_participant_broadcasts_room_updated(django_user_client, graphql_use
     added = added_calls[0].kwargs["added_participants"]
     assert len(added) == 1
     assert added[0].profile_id == contact.pk
+
+
+def test_add_participant_notification_failure_does_not_fail_mutation(
+    django_user_client, graphql_user_client
+):
+    contact = ProfileFactory(name="Contact Person")
+    my_profile = django_user_client.user.profile
+    room_a = _make_group(my_profile, members=[ProfileFactory()])
+    room_b = _make_group(my_profile, members=[ProfileFactory()])
+
+    with mock.patch(
+        "baseapp_chats.graphql.mutations.ChatRoomOnRoomUpdate.room_updated",
+        side_effect=Exception("broadcast down"),
+    ):
+        response = graphql_user_client(
+            ADD_PARTICIPANT_TO_ROOMS_GRAPHQL,
+            variables={
+                "input": {
+                    "profileId": my_profile.relay_id,
+                    "participantProfileId": contact.relay_id,
+                    "roomIds": [room_a.relay_id, room_b.relay_id],
+                },
+                "participantProfileId": contact.relay_id,
+            },
+        )
+
+    # Memberships are committed before notifications run: a broadcast failure
+    # must not surface as a mutation error nor roll anything back
+    content = response.json()
+    assert not content["data"]["chatRoomsAddParticipant"]["errors"]
+    assert len(content["data"]["chatRoomsAddParticipant"]["addedParticipants"]) == 2
+    for room in (room_a, room_b):
+        assert ChatRoomParticipant.objects.filter(room=room, profile=contact).exists()
 
 
 def test_add_participant_requires_authentication(django_client):

--- a/baseapp_chats/tests/test_graphql_queries.py
+++ b/baseapp_chats/tests/test_graphql_queries.py
@@ -1287,3 +1287,155 @@ def test_resolve_is_sole_admin_when_admin_leaves_and_another_becomes_sole_admin(
 
     content = response.json()
     assert content["data"]["chatRoom"]["isSoleAdmin"] is True
+
+
+MANAGEABLE_ROOMS_GRAPHQL = """
+    query ManageableRooms($profileId: ID!, $manageable: Boolean, $q: String, $contactId: ID!) {
+        profile(id: $profileId) {
+            id
+            ... on ChatRoomsInterface {
+                chatRooms(manageable: $manageable, q: $q) {
+                    edges {
+                        node {
+                            id
+                            title
+                            participantsCount
+                            isParticipant(profileId: $contactId)
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
+
+def _make_room(profile, role, is_group=True, title=None, members=()):
+    room = ChatRoomFactory(is_group=is_group, title=title)
+    ChatRoomParticipantFactory(room=room, profile=profile, role=role)
+    for member in members:
+        ChatRoomParticipantFactory(
+            room=room,
+            profile=member,
+            role=ChatRoomParticipant.ChatRoomParticipantRoles.MEMBER,
+        )
+    room.participants_count = 1 + len(members)
+    room.save(update_fields=["participants_count"])
+    return room
+
+
+def test_manageable_filter_returns_only_admin_group_rooms(django_user_client, graphql_user_client):
+    my_profile = django_user_client.user.profile
+    contact = ProfileFactory()
+    roles = ChatRoomParticipant.ChatRoomParticipantRoles
+
+    admin_group = _make_room(
+        my_profile, roles.ADMIN, title="admin group", members=[ProfileFactory()]
+    )
+    # member-only group must be excluded
+    _make_room(my_profile, roles.MEMBER, title="member group", members=[ProfileFactory()])
+    # 1:1 room where user is ADMIN (creators get ADMIN) must be excluded too
+    _make_room(my_profile, roles.ADMIN, is_group=False, members=[ProfileFactory()])
+    # unrelated group must be excluded
+    _make_room(ProfileFactory(), roles.ADMIN, title="other group", members=[ProfileFactory()])
+
+    response = graphql_user_client(
+        MANAGEABLE_ROOMS_GRAPHQL,
+        variables={
+            "profileId": my_profile.relay_id,
+            "manageable": True,
+            "contactId": contact.relay_id,
+        },
+    )
+    edges = response.json()["data"]["profile"]["chatRooms"]["edges"]
+    assert len(edges) == 1
+    assert edges[0]["node"]["id"] == admin_group.relay_id
+    assert edges[0]["node"]["isParticipant"] is False
+
+
+def test_manageable_filter_combined_with_q(django_user_client, graphql_user_client):
+    my_profile = django_user_client.user.profile
+    contact = ProfileFactory()
+    roles = ChatRoomParticipant.ChatRoomParticipantRoles
+
+    matching = _make_room(my_profile, roles.ADMIN, title="Book club", members=[ProfileFactory()])
+    _make_room(my_profile, roles.ADMIN, title="Hiking crew", members=[ProfileFactory()])
+
+    response = graphql_user_client(
+        MANAGEABLE_ROOMS_GRAPHQL,
+        variables={
+            "profileId": my_profile.relay_id,
+            "manageable": True,
+            "q": "book",
+            "contactId": contact.relay_id,
+        },
+    )
+    edges = response.json()["data"]["profile"]["chatRooms"]["edges"]
+    assert len(edges) == 1
+    assert edges[0]["node"]["id"] == matching.relay_id
+
+
+def test_manageable_false_returns_all_member_rooms(django_user_client, graphql_user_client):
+    my_profile = django_user_client.user.profile
+    contact = ProfileFactory()
+    roles = ChatRoomParticipant.ChatRoomParticipantRoles
+
+    _make_room(my_profile, roles.ADMIN, title="admin group", members=[ProfileFactory()])
+    _make_room(my_profile, roles.MEMBER, title="member group", members=[ProfileFactory()])
+
+    response = graphql_user_client(
+        MANAGEABLE_ROOMS_GRAPHQL,
+        variables={
+            "profileId": my_profile.relay_id,
+            "manageable": False,
+            "contactId": contact.relay_id,
+        },
+    )
+    edges = response.json()["data"]["profile"]["chatRooms"]["edges"]
+    assert len(edges) == 2
+
+
+def test_is_participant_true_for_member_false_for_non_member(
+    django_user_client, graphql_user_client
+):
+    my_profile = django_user_client.user.profile
+    contact = ProfileFactory()
+    roles = ChatRoomParticipant.ChatRoomParticipantRoles
+
+    room_with_contact = _make_room(my_profile, roles.ADMIN, title="with contact", members=[contact])
+    room_without_contact = _make_room(
+        my_profile, roles.ADMIN, title="without contact", members=[ProfileFactory()]
+    )
+
+    response = graphql_user_client(
+        MANAGEABLE_ROOMS_GRAPHQL,
+        variables={
+            "profileId": my_profile.relay_id,
+            "manageable": True,
+            "contactId": contact.relay_id,
+        },
+    )
+    edges = response.json()["data"]["profile"]["chatRooms"]["edges"]
+    by_id = {edge["node"]["id"]: edge["node"]["isParticipant"] for edge in edges}
+    assert by_id[room_with_contact.relay_id] is True
+    assert by_id[room_without_contact.relay_id] is False
+
+
+def test_is_participant_with_invalid_profile_id_returns_null(
+    django_user_client, graphql_user_client
+):
+    my_profile = django_user_client.user.profile
+    roles = ChatRoomParticipant.ChatRoomParticipantRoles
+    _make_room(my_profile, roles.ADMIN, title="group", members=[ProfileFactory()])
+
+    response = graphql_user_client(
+        MANAGEABLE_ROOMS_GRAPHQL,
+        variables={
+            "profileId": my_profile.relay_id,
+            "manageable": True,
+            "contactId": "not-a-valid-relay-id",
+        },
+    )
+    edges = response.json()["data"]["profile"]["chatRooms"]["edges"]
+    assert len(edges) == 1
+    assert edges[0]["node"]["isParticipant"] is None

--- a/baseapp_chats/tests/test_graphql_query_counts.py
+++ b/baseapp_chats/tests/test_graphql_query_counts.py
@@ -12,6 +12,8 @@ Modelled after:
   the count alone is too coarse).
 """
 
+from collections import Counter
+
 import pytest
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
@@ -289,4 +291,85 @@ def test_chat_room_filter_unread_messages_prefetches_unread_messages(
         "`ChatRoomFilter.filter_unread_messages` lost its prefetch_related "
         "call, or the queryset got re-evaluated mid-pagination. "
         f"Offending queries: {prefetch_queries}"
+    )
+
+
+MANAGEABLE_ROOMS_WITH_IS_PARTICIPANT_LISTING = """
+    query ManageableRooms($profileId: ID!, $contactId: ID!) {
+        profile(id: $profileId) {
+            id
+            ... on ChatRoomsInterface {
+                chatRooms(manageable: true) {
+                    edges {
+                        node {
+                            id
+                            title
+                            participantsCount
+                            isParticipant(profileId: $contactId)
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
+
+def test_manageable_listing_with_is_participant_stays_linear(
+    graphql_user_client, django_user_client
+):
+    """Bound guard for the add-contact-to-group listing.
+
+    `isParticipant(profileId:)` resolves one indexed EXISTS per row —
+    an accepted per-row cost bounded by page size (same precedent as
+    `resolve_is_archived`). The relay-id decode of `profileId` is
+    memoized per request, so it must NOT scale with row count.
+
+    Baseline for 5 rooms is 26 queries: ~21 fixed (request setup,
+    documentid decodes, permission + blocks checks, metadata tables,
+    COUNT + page) + 1 EXISTS per room. The bound absorbs minor churn;
+    a second per-row query (e.g. an un-memoized decode, or hydrating
+    participant profiles like `participant_ids` does) adds +5 and
+    trips it immediately.
+    """
+    import swapper
+
+    from baseapp_profiles.tests.factories import ProfileFactory as _ProfileFactory
+
+    ChatRoomParticipant = swapper.load_model("baseapp_chats", "ChatRoomParticipant")
+    roles = ChatRoomParticipant.ChatRoomParticipantRoles
+
+    my_profile = django_user_client.user.profile
+    contact = _ProfileFactory()
+
+    n_rooms = 5
+    for i in range(n_rooms):
+        room = ChatRoomFactory(is_group=True, title=f"group {i}")
+        ChatRoomParticipantFactory(room=room, profile=my_profile, role=roles.ADMIN)
+        ChatRoomParticipantFactory(room=room, profile=_ProfileFactory(), role=roles.MEMBER)
+        room.participants_count = 2
+        room.save(update_fields=["participants_count"])
+
+    with CaptureQueriesContext(connection) as ctx:
+        response = graphql_user_client(
+            MANAGEABLE_ROOMS_WITH_IS_PARTICIPANT_LISTING,
+            variables={
+                "profileId": my_profile.relay_id,
+                "contactId": contact.relay_id,
+            },
+        )
+
+    assert "errors" not in response.json(), response.json()
+    fixed_overhead = 24
+    tables = Counter()
+    for captured in ctx.captured_queries:
+        for token in captured["sql"].split('FROM "')[1:]:
+            tables[token.split('"')[0]] += 1
+    assert len(ctx.captured_queries) <= fixed_overhead + n_rooms, (
+        f"Manageable listing issued {len(ctx.captured_queries)} queries for "
+        f"{n_rooms} rooms. Table histogram: {dict(tables)}\n"
+        "Likely causes:\n"
+        "  - `resolve_is_participant` started hydrating profiles instead of EXISTS\n"
+        "  - the `manageable` filter join lost `.distinct()` and duplicated rows\n"
+        "  - a per-row COUNT crept into `participants_count` resolution"
     )

--- a/baseapp_chats/utils.py
+++ b/baseapp_chats/utils.py
@@ -5,6 +5,7 @@ import swapper
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db.models import Model
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from baseapp_core.plugins import shared_services
@@ -71,6 +72,34 @@ def send_message(
     ChatRoomOnMessage.new_message(room_id=room_id or room.relay_id, message=message)
 
     return message
+
+
+def add_profiles_to_room(room: Model, profile_pks: Iterable[int | str]) -> list[Model]:
+    """Add profiles as MEMBER participants to a room, silently skipping existing members.
+
+    Returns the created ChatRoomParticipant rows. Callers own the update of
+    room.participants_count.
+    """
+    ChatRoomParticipant = swapper.load_model("baseapp_chats", "ChatRoomParticipant")
+
+    unique_profile_pks = list(set(profile_pks))
+    existing_profile_pks = ChatRoomParticipant.objects.filter(
+        room=room, profile__pk__in=unique_profile_pks
+    ).values_list("profile__pk", flat=True)
+
+    new_profile_pks = [pk for pk in unique_profile_pks if int(pk) not in existing_profile_pks]
+
+    return ChatRoomParticipant.objects.bulk_create(
+        [
+            ChatRoomParticipant(
+                profile_id=profile_pk,
+                room=room,
+                role=ChatRoomParticipant.ChatRoomParticipantRoles.MEMBER,
+                accepted_at=timezone.now(),
+            )
+            for profile_pk in new_profile_pks
+        ]
+    )
 
 
 def escape_format_braces(value: str) -> str:

--- a/baseapp_chats/utils.py
+++ b/baseapp_chats/utils.py
@@ -78,16 +78,20 @@ def add_profiles_to_room(room: Model, profile_pks: Iterable[int | str]) -> list[
     """Add profiles as MEMBER participants to a room, silently skipping existing members.
 
     Returns the created ChatRoomParticipant rows. Callers own the update of
-    room.participants_count.
+    room.participants_count. The check-then-insert is only idempotent while the
+    room row is locked — callers that can run concurrently must hold a lock on
+    the room (e.g. select_for_update) before calling.
     """
     ChatRoomParticipant = swapper.load_model("baseapp_chats", "ChatRoomParticipant")
 
-    unique_profile_pks = list(set(profile_pks))
-    existing_profile_pks = ChatRoomParticipant.objects.filter(
-        room=room, profile__pk__in=unique_profile_pks
-    ).values_list("profile__pk", flat=True)
+    unique_profile_pks = {int(pk) for pk in profile_pks}
+    existing_profile_pks = set(
+        ChatRoomParticipant.objects.filter(
+            room=room, profile__pk__in=unique_profile_pks
+        ).values_list("profile__pk", flat=True)
+    )
 
-    new_profile_pks = [pk for pk in unique_profile_pks if int(pk) not in existing_profile_pks]
+    new_profile_pks = unique_profile_pks - existing_profile_pks
 
     return ChatRoomParticipant.objects.bulk_create(
         [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “manageable” chat room filtering for the current profile (admin-only group rooms) and the `isParticipant(profileId:)` field.
  * Added a GraphQL mutation to add a participant to multiple group rooms in one request (idempotent for existing memberships).
* **Bug Fixes**
  * Multi-room additions are all-or-nothing when any target room is invalid or unauthorized.
  * Notification/broadcast errors no longer undo successful membership changes.
* **Tests**
  * Added coverage for multi-room semantics, `isParticipant` behavior, and a query-count performance regression for manageable listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->