### PR TITLE
fix(reports): make report-type query tests hermetic for parallel runs

### DIFF
--- a/baseapp_reports/tests/test_graphql_queries.py
+++ b/baseapp_reports/tests/test_graphql_queries.py
@@ -58,29 +58,45 @@ query ProfileMyReport($nodeId: ID!) {
 
 
 def test_anon_can_list_report_types(graphql_client):
+    # Self-contained: create our own types and assert they appear, rather than relying on
+    # the migration-seeded defaults (which any TransactionTestCase in the suite truncates,
+    # making this flaky under pytest-xdist). Explicit keys keep assertions deterministic.
+    ReportTypeFactory(key="qa_list_a")
+    ReportTypeFactory(key="qa_list_b")
     response = graphql_client(REPORT_TYPES_LIST_GRAPHQL)
     content = response.json()
     assert "errors" not in content
-    assert len(content["data"]["allReportTypes"]["edges"]) > 0
+    keys = {edge["node"]["key"] for edge in content["data"]["allReportTypes"]["edges"]}
+    assert {"qa_list_a", "qa_list_b"} <= keys
 
 
 def test_anon_can_get_report_type_filtered_by_top_level(graphql_client):
+    top_level = ReportTypeFactory(key="qa_top_level")
+    ReportTypeFactory(key="qa_subtype", parent_type=top_level)
     response = graphql_client(REPORT_TYPES_LIST_GRAPHQL, variables={"topLevelOnly": True})
     content = response.json()
-    assert (
-        len(content["data"]["allReportTypes"]["edges"]) == 8
-    )  # 11 total created by baseapp_reports migrations, with 3 subtypes
+    assert "errors" not in content
+    keys = {edge["node"]["key"] for edge in content["data"]["allReportTypes"]["edges"]}
+    assert "qa_top_level" in keys
+    assert "qa_subtype" not in keys  # subtypes are excluded by topLevelOnly
 
 
 def test_anon_can_get_report_type_filtered_by_content_type(graphql_client):
-    other_profile = ProfileFactory()
+    target_profile = ProfileFactory()
+    # A type wired to the target's content type is returned; one wired to a different
+    # content type is not.
+    matching = ReportTypeFactory(key="qa_match")
+    matching.content_types.set([ContentType.objects.get_for_model(target_profile)])
+    other = ReportTypeFactory(key="qa_other")
+    other.content_types.set([ContentType.objects.get_for_model(Report)])
     response = graphql_client(
-        REPORT_TYPES_LIST_GRAPHQL, variables={"targetObjectId": other_profile.relay_id}
+        REPORT_TYPES_LIST_GRAPHQL, variables={"targetObjectId": target_profile.relay_id}
     )
     content = response.json()
-    assert (
-        len(content["data"]["allReportTypes"]["edges"]) == 8
-    )  # 11 total, with 3 being exclusive to comments
+    assert "errors" not in content
+    keys = {edge["node"]["key"] for edge in content["data"]["allReportTypes"]["edges"]}
+    assert "qa_match" in keys
+    assert "qa_other" not in keys
 
 
 def test_reports_interface_resolve_reports_filters_by_target_profile(


### PR DESCRIPTION
The allReportTypes query tests asserted on migration-seeded ReportType rows (counts of 8/11). Any TransactionTestCase in the suite truncates those rows (Django does not restore migration data without serialized_rollback), so under pytest-xdist the wipe can land before these tests on a shared worker DB, making them flaky.

Create and assert on the tests' own ReportType rows (explicit keys, membership assertions) instead of the seeded defaults, so they are order- and scheduler-independent.